### PR TITLE
Csr feat/implement parser layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-# Only run on the FleetProvisioning_beta branch for now.
+# Only run on the feat/csr-in-fleet-provisioning branch for now.
 branches:
   only:
-  - FleetProvisioning_beta
+  - feat/csr-in-fleet-provisioning
 
 # Build on Ubuntu 16.04 by default.
 os: linux

--- a/libraries/aws/provisioning/include/aws_iot_provisioning.h
+++ b/libraries/aws/provisioning/include/aws_iot_provisioning.h
@@ -42,6 +42,7 @@
  * @functionspage{provisioning,Provisioning library}
  * - @functionname{provisioning_function_init}
  * - @functionname{provisioning_function_createkeysandcertificate}
+ * - @functionname{provisioning_function_createcertificatefromcsr}
  * - @functionname{provisioning_function_registerthing}
  * - @functionname{provisioning_function_cleanup}
  * - @functionname{provisioning_function_strerror}
@@ -50,6 +51,7 @@
 /**
  * @functionpage{AwsIotProvisioning_Init,provisioning,init}
  * @functionpage{AwsIotProvisioning_CreateKeysAndCertificate,provisioning,createkeysandcertificate}
+ * @functionpage{AwsIotProvisioning_CreateCertificateFromCsr,provisioning,createcertificatefromcsr}
  * @functionpage{AwsIotProvisioning_RegisterThing,provisioning,registerthing}
  * @functionpage{AwsIotProvisioning_Cleanup,provisioning,cleanup}
  * @functionpage{AwsIotProvisioning_strerror,provisioning,strerror}
@@ -78,92 +80,171 @@
 AwsIotProvisioningError_t AwsIotProvisioning_Init( uint32_t mqttTimeout );
 /* @[declare_provisioning_init] */
 
-
 /**
- * @brief Requests a new public-private key pair and certificate for the device from AWS IoT Core and
- * invokes the provided user-callback with the response from the server.
+ * @brief Requests a new public-private key pair and certificate for the device
+ * from AWS IoT Core and invokes the provided user-callback with the response from
+ * the server.
  *
- * @note It is advised to use a shared MQTT connection to AWS IoT Core across all API functions
+ * @note It is advised to use a shared MQTT connection to AWS IoT Core across all
+ * API functions.
  *
- * @warning This function is NOT thread-safe. Concurrent calls to the library API functions can result in undefined
- * behavior. Device provisioning with this library REQUIRES calling the API functions of this library sequentially.
+ * @warning This function is NOT thread-safe. Concurrent calls to the library API
+ * functions can result in undefined behavior. Device provisioning with this library
+ * REQUIRES calling the API functions of this library sequentially.
  *
- * @param[in] provisioningConnection The MQTT connection handle to the user AWS IoT account, which will be used for
- * communicating with the server for creating new device credentials.
- * @param[in] flags The flags for configuring the behavior of the API. See the options available in the
- * aws_iot_provisioning_types.h file.
- * @param[in] timeoutMs The timeout (in milliseconds) for a response from the server. If there is a timeout, this
- * function returns #AWS_IOT_PROVISIONING_TIMEOUT.
- * @param[in] pResponseCallback The user-defined callback that will be invoked with the response from the server,
- * whether new credentials for the device in case of success, OR error response in case of server rejection of the
- * credentials generation request.
- * The callback should be defined appropriately for storing the credentials provided by the server on the device.
- * @warning Do not overwrite the existing Provisioning claim credentials with the new credentials provided by
- * the server. It is RECOMMENDED NOT to delete the certificate and private key used for the passed connection handle
- * until the device has been provisioned with a new certificate with the @ref provisioning_function_registerthing
- * function.
+ * @param[in] connection The MQTT connection handle to the user AWS IoT account, which
+ * will be used for communicating with the server for creating new device credentials.
+ * @param[in] flags The flags for configuring the behavior of the API. See the options
+ * available in the aws_iot_provisioning_types.h file.
+ * @param[in] timeoutMs The timeout (in milliseconds) for a response from the server.
+ * If there is a timeout, this function returns #AWS_IOT_PROVISIONING_TIMEOUT.
+ * @param[in] pResponseCallback The user-defined callback that will be invoked with the
+ * response from the server, whether new credentials for the device in case of success,
+ * OR error response in case of server rejection of the credentials generation request.
+ * The callback should be defined appropriately for storing the credentials provided by
+ * the server on the device.
+ * @warning Do not overwrite the existing Provisioning claim credentials with the new
+ * credentials provided by the server, at least until the device has been provisioned
+ * with a new certificate using the @ref provisioning_function_registerthing function.
+ * It is also recommended to always retain the Provisioning claim credentials,
+ * if the claim certificate is long-lived.
  * @return This function will return #AWS_IOT_PROVISIONING_SUCCESS upon success; otherwise,
- *   #AWS_IOT_PROVISIONING_NOT_INITIALIZED, if the API is called without initializing the Provisioning library (i.e.
- *   with a prior call to @ref AwsIotProvisioning_Init function.)
+ *   #AWS_IOT_PROVISIONING_NOT_INITIALIZED, if the API is called without initializing
+ *   the Provisioning library (i.e. with a prior call to @ref AwsIotProvisioning_Init function.)
  *   #AWS_IOT_PROVISIONING_BAD_PARAMETER, if one or more input parameters are invalid.
- *   #AWS_IOT_PROVISIONING_NO_MEMORY, if there is insufficient memory for allocation in internal operations.
+ *   #AWS_IOT_PROVISIONING_NO_MEMORY, if there is insufficient memory for
+ *   allocation in internal operations.
  *   #AWS_IOT_PROVISIONING_MQTT_ERROR, for errors from the MQTT stack.
- *   #AWS_IOT_PROVISIONING_TIMEOUT, if there is a timeout in waiting for the server response for the request to
- *   generate new credentials for the device.
- *   #AWS_IOT_PROVISIONING_SERVER_REFUSED, if the server rejects the request for generating device credentials.
- *   #AWS_IOT_PROVISIONING_BAD_RESPONSE, if the response from the server cannot be successfully parsed or comprehended.
- *   #AWS_IOT_PROVISIONING_INTERNAL_FAILURE, if any there are operation failures internal to the library.
+ *   #AWS_IOT_PROVISIONING_TIMEOUT, if there is a timeout in waiting for the server
+ *   response for the request to generate new credentials for the device.
+ *   #AWS_IOT_PROVISIONING_SERVER_REFUSED, if the server rejects the request for
+ *   generating device credentials.
+ *   #AWS_IOT_PROVISIONING_BAD_RESPONSE, if the response from the server cannot be
+ *   successfully parsed or comprehended.
+ *   #AWS_IOT_PROVISIONING_INTERNAL_FAILURE, if any there are operation failures
+ *   internal to the library.
  */
 /* @[declare_provisioning_createkeysandcertificate] */
-AwsIotProvisioningError_t AwsIotProvisioning_CreateKeysAndCertificate( IotMqttConnection_t provisioningConnection,
+AwsIotProvisioningError_t AwsIotProvisioning_CreateKeysAndCertificate( IotMqttConnection_t connection,
                                                                        uint32_t flags,
                                                                        uint32_t timeoutMs,
                                                                        const AwsIotProvisioningCreateKeysAndCertificateCallbackInfo_t * pResponseCallback );
 /* @[declare_provisioning_createkeysandcertificate] */
 
 /**
- * @brief Requests the AWS IoT Core service to register the device, and invokes the user-defined callback with the
- * response it receives from the server.
+ * @brief Requests the AWS IoT Core service for a certificate by sending a
+ * Certificate-Signing Request, and invokes the provided user-defined response
+ * handler with the response it receives from the server.
  *
- * For provisioning the device, the service is expected to register the certificate, and optionally set up the Thing,
- * Attributes and other cloud settings based on the fleet provisioning template and device context information that are
- * passed to the API.
+ * @note It is advised to use a shared MQTT connection to AWS IoT Core across
+ * all API functions.
  *
- * @note The device should be connected to the user AWS IoT account over MQTT and the calling code should provide the
- * MQTT connection handle to the API for communicating with the server.
+ * @warning This function is NOT thread-safe. Concurrent calls to the library
+ * API functions can result in undefined behavior. Device provisioning with this
+ * library REQUIRES calling the API functions of this library sequentially.
  *
- * Also, the AWS IoT account being connected to for provisioning the device SHOULD have a fleet provisioning template
- * created, whose template name should be passed to this API for requesting device provisioning.
+ * @param[in] connection The MQTT connection handle that will be used to communicate
+ * with AWS IoT Core for the Certificate-Signing Request.
+ * @param[in] operationQos The Quality of Service (QoS) level for the MQTT
+ * publish/subscribe communication with the server.
+ * @param[in] pCertificateSigningRequest The PEM encoded string for the
+ * Certificate-Signing Request.
+ * @param[in] csrLength The length of the Certificate-Signing Request string.
+ * @param[in] timeoutMs The timeout (in milliseconds) for a response from the server.
+ * If there is a timeout, this function returns #AWS_IOT_PROVISIONING_TIMEOUT.
+ * @param[in] pResponseCallback The user-defined callback that will be invoked with
+ * the server's response to the CSR request. The server can respond either with the
+ * new certificate information (in case of request acceptance) OR with error (in case
+ * of request rejection).
  *
- * @warning This function is NOT thread-safe. Concurrent calls to the library API functions can result in undefined
- * behavior. Device provisioning with this library REQUIRES calling the API functions of this library sequentially.
+ * @note The callback is expected to store/retain the new certificate information from
+ * the server response, which will be required for registering the device with
+ * @ref provisioning_function_registerthing function.
  *
- * @param[in] provisioningConnection The MQTT connection handle to the user AWS IoT account that will be used for
- * provisioning the device.
- * @param[in] pProvisioningDataInfo The data (including the certificate) that needs to be sent to the server for
- * provisioning the device.
- * @param[in] timeoutMs The timeout (in milliseconds) for a response from the server. If there is a timeout, this
- * function returns #AWS_IOT_PROVISIONING_TIMEOUT.
- * @param[in] pResponseCallback The user-defined functor that will be called with the response received from the server,
- * whether post-provisioning data in case of success OR error message in case of server rejection of provisioning
- * request.
- * @note In case of success response, the server may send device-specific configuration data, which will be provided as
- * a list of key-value pairs in the callback.
- * @return This function will return #AWS_IOT_PROVISIONING_SUCCESS upon success; otherwise,
- *   #AWS_IOT_PROVISIONING_NOT_INITIALIZED, if the API is called without initializing the Provisioning library (i.e.
- *   with a prior call to @ref AwsIotProvisioning_Init function.)
+ * @warning Do not overwrite the existing Provisioning claim credentials with the new
+ * credentials provided by the server, at least until the device has been provisioned
+ * with a new certificate using the @ref provisioning_function_registerthing function.
+ * It is also recommended to always retain the Provisioning claim credentials,
+ * if the claim certificate is long-lived.
+ * @return This function will return #AWS_IOT_PROVISIONING_SUCCESS upon success;
+ *   otherwise,
+ *   #AWS_IOT_PROVISIONING_NOT_INITIALIZED, if the API is called without initializing the
+ *   Provisioning library (i.e. with a prior call to @ref AwsIotProvisioning_Init function.)
  *   #AWS_IOT_PROVISIONING_BAD_PARAMETER, if one or more input parameters are invalid.
- *   #AWS_IOT_PROVISIONING_NO_MEMORY, if there is insufficient memory for allocation in internal operations.
+ *   #AWS_IOT_PROVISIONING_NO_MEMORY, if there is insufficient memory for allocation
+ *   in internal operations.
  *   #AWS_IOT_PROVISIONING_MQTT_ERROR, for errors from the MQTT stack.
- *   #AWS_IOT_PROVISIONING_TIMEOUT, if there is a timeout in waiting for the server response for the request to
- *   provision device.
- *   #AWS_IOT_PROVISIONING_SERVER_REFUSED, if the server rejects the request for provisioning the device.
- *   #AWS_IOT_PROVISIONING_BAD_RESPONSE, if the response from the server cannot be successfully parsed or comprehended.
- *   #AWS_IOT_PROVISIONING_INTERNAL_FAILURE, if any there are operation failures internal to the library.
+ *   #AWS_IOT_PROVISIONING_TIMEOUT, if there is a timeout in waiting for the server
+ *   response for the request to generate new credentials for the device.
+ *   #AWS_IOT_PROVISIONING_SERVER_REFUSED, if the server rejects the request for
+ *   generating device credentials.
+ *   #AWS_IOT_PROVISIONING_BAD_RESPONSE, if the response from the server cannot be
+ *   successfully parsed or comprehended.
+ *   #AWS_IOT_PROVISIONING_INTERNAL_FAILURE, if any there are operation failures internal
+ *   to the library.
+ */
+/* @[declare_provisioning_createcertificatefromcsr] */
+AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttConnection_t connection,
+                                                                       IotMqttQos_t operationQos,
+                                                                       const char * pCertificateSigningRequest,
+                                                                       size_t csrLength,
+                                                                       uint32_t timeoutMs,
+                                                                       const AwsIotProvisioningCreateCertFromCsrCallbackInfo_t * pResponseCallback );
+/* @[declare_provisioning_createcertificatefromcsr] */
+
+/**
+ * @brief Requests the AWS IoT Core service to register the device, and invokes
+ * the user-defined callback with the response it receives from the server.
+ *
+ * For registering the device, the service is expected to provide the new certificate,
+ * and optionally set up the Thing, Attributes and other cloud settings based on
+ * the fleet provisioning template and device context information that are passed
+ * to the API.
+ *
+ * @note It is advised to use a shared MQTT connection to AWS IoT Core across all
+ * API functions.
+ *
+ * Also, the AWS IoT account being connected to for registering the device SHOULD
+ * have a fleet provisioning template created, whose template name should be passed
+ * to this API for requesting device registration.
+ *
+ * @warning This function is NOT thread-safe. Concurrent calls to the library API
+ * functions can result in undefined behavior. Device provisioning with this library
+ * REQUIRES calling the API functions of this library sequentially.
+ *
+ * @param[in] connection The MQTT connection handle to the user AWS IoT account that
+ * will be used for registering the device.
+ * @param[in] pProvisioningDataInfo The data (including the certificate) that needs
+ * to be sent to the server for registering the device.
+ * @param[in] timeoutMs The timeout (in milliseconds) for a response from the server.
+ * If there is a timeout, this function returns #AWS_IOT_PROVISIONING_TIMEOUT.
+ * @param[in] pResponseCallback The user-defined functor that will be called with the
+ * response received from the server, whether post-provisioning data in case of
+ * success OR error message in case of server rejection of registration request.
+ * @note In case of success response, the server may send device-specific
+ * configuration data, which will be provided as a list of key-value pairs in the
+ * callback.
+ * @return This function will return #AWS_IOT_PROVISIONING_SUCCESS upon success;
+ *   otherwise,
+ *   #AWS_IOT_PROVISIONING_NOT_INITIALIZED, if the API is called without initializing
+ *   the Provisioning library (i.e. with a prior call to @ref AwsIotProvisioning_Init
+ *   function.)
+ *   #AWS_IOT_PROVISIONING_BAD_PARAMETER, if one or more input parameters are invalid.
+ *   #AWS_IOT_PROVISIONING_NO_MEMORY, if there is insufficient memory for allocation
+ *   in internal operations.
+ *   #AWS_IOT_PROVISIONING_MQTT_ERROR, for errors from the MQTT stack.
+ *   #AWS_IOT_PROVISIONING_TIMEOUT, if there is a timeout in waiting for the server
+ *   response for the request to register the device.
+ *   #AWS_IOT_PROVISIONING_SERVER_REFUSED, if the server rejects the request for
+ *   register the device.
+ *   #AWS_IOT_PROVISIONING_BAD_RESPONSE, if the response from the server cannot be
+ *   successfully parsed or comprehended.
+ *   #AWS_IOT_PROVISIONING_INTERNAL_FAILURE, if any there are operation failures
+ *   internal to the library.
  */
 /* @[declare_provisioning_registerthing] */
 
-AwsIotProvisioningError_t AwsIotProvisioning_RegisterThing( IotMqttConnection_t provisioningConnection,
+AwsIotProvisioningError_t AwsIotProvisioning_RegisterThing( IotMqttConnection_t connection,
                                                             const AwsIotProvisioningRegisterThingRequestInfo_t * pProvisioningDataInfo,
                                                             uint32_t timeoutMs,
                                                             const AwsIotProvisioningRegisterThingCallbackInfo_t * pResponseCallback );

--- a/libraries/aws/provisioning/include/types/aws_iot_provisioning_types.h
+++ b/libraries/aws/provisioning/include/types/aws_iot_provisioning_types.h
@@ -302,7 +302,7 @@ typedef struct AwsIotProvisioningCreateCertFromCsrResponse
         /** @brief Represents the successful/accepted response of device credentials received from the server. */
         struct
         {
-            const char * pDeviceCertificate;  /**< The new certificate for the device.*/
+            const char * pDeviceCert;         /**< The new certificate for the device.*/
             size_t deviceCertLength;          /**< The size of the device certificate.*/
             const char * pCertId;             /**< The certificate ID associated with the new certificate,
                                                * @p pDeviceCertificate.*/

--- a/libraries/aws/provisioning/include/types/aws_iot_provisioning_types.h
+++ b/libraries/aws/provisioning/include/types/aws_iot_provisioning_types.h
@@ -154,6 +154,11 @@ typedef enum AwsIotProvisioningServerStatusCode
     AWS_IOT_PROVISIONING_SERVER_STATUS_ACCEPTED = 202,
 
     /**
+     * @brief Provisioning operation rejected: Invalid Certificate-Signing Request.
+     */
+    AWS_IOT_PROVISIONING_SERVER_STATUS_INVALID_CSR = 400,
+
+    /**
      * @brief Provisioning operation rejected: Forbidden.
      */
     AWS_IOT_PROVISIONING_SERVER_STATUS_FORBIDDEN = 403,

--- a/libraries/aws/provisioning/include/types/aws_iot_provisioning_types.h
+++ b/libraries/aws/provisioning/include/types/aws_iot_provisioning_types.h
@@ -297,14 +297,14 @@ typedef struct AwsIotProvisioningCreateCertFromCsrResponse
         /** @brief Represents the successful/accepted response of device credentials received from the server. */
         struct
         {
-            const char * pDeviceCertificate;         /**< The new certificate for the device.*/
-            size_t deviceCertificateLength;          /**< The size of the device certificate.*/
-            const char * pCertificateId;             /**< The certificate ID associated with the new certificate,
-                                                      * @p pDeviceCertificate.*/
-            size_t certificateIdLength;              /**< The length of the certificate ID.*/
-            const char * pCertificateOwnershipToken; /**< The token that represents ownership of certificate and
-                                                      * associated private key that the device.*/
-            size_t ownershipTokenLength;             /**< The size of the ownership token.*/
+            const char * pDeviceCertificate;  /**< The new certificate for the device.*/
+            size_t deviceCertLength;          /**< The size of the device certificate.*/
+            const char * pCertId;             /**< The certificate ID associated with the new certificate,
+                                               * @p pDeviceCertificate.*/
+            size_t certIdLength;              /**< The length of the certificate ID.*/
+            const char * pCertOwnershipToken; /**< The token that represents ownership of certificate and
+                                               * associated private key that the device.*/
+            size_t ownershipTokenLength;      /**< The size of the ownership token.*/
         } acceptedResponse;
 
         /** @brief Represents the rejected response information received from the server. */

--- a/libraries/aws/provisioning/include/types/aws_iot_provisioning_types.h
+++ b/libraries/aws/provisioning/include/types/aws_iot_provisioning_types.h
@@ -57,7 +57,7 @@ typedef enum AwsIotProvisioningError
      *
      * Functions that may return this value:
      */
-    AWS_IOT_PROVISIONING_SUCCESS = 0,
+    AWS_IOT_PROVISIONING_SUCCESS = 1,
 
     /**
      * @brief Library initialization failure.
@@ -279,6 +279,76 @@ typedef struct AwsIotProvisioningRejectedResponse
 
 /**
  * @ingroup provisioning_datatypes_paramstructs
+ * @brief Aggregates the data from AWS IoT Core's response to the certificate creation request with a CSR.
+ *
+ * @paramfor Response Callback function of @ref provisioning_function_createkeysandcertificate
+ *
+ * The @ref AwsIotProvisioning_CreateKeysAndCertificate library API passes this object to a user-provided callback
+ * function
+ * whenever the operation completes with a response from the server.
+ */
+typedef struct AwsIotProvisioningCreateCertFromCsrResponse
+{
+    /** @brief The highest level HTTP based status code sent by the server. */
+    AwsIotProvisioningServerStatusCode_t statusCode;
+
+    union
+    {
+        /** @brief Represents the successful/accepted response of device credentials received from the server. */
+        struct
+        {
+            const char * pDeviceCertificate;         /**< The new certificate for the device.*/
+            size_t deviceCertificateLength;          /**< The size of the device certificate.*/
+            const char * pCertificateId;             /**< The certificate ID associated with the new certificate,
+                                                      * @p pDeviceCertificate.*/
+            size_t certificateIdLength;              /**< The length of the certificate ID.*/
+            const char * pCertificateOwnershipToken; /**< The token that represents ownership of certificate and
+                                                      * associated private key that the device.*/
+            size_t ownershipTokenLength;             /**< The size of the ownership token.*/
+        } acceptedResponse;
+
+        /** @brief Represents the rejected response information received from the server. */
+        AwsIotProvisioningRejectedResponse_t rejectedResponse;
+    } u; /**< @brief Valid member depends on operation status. */
+} AwsIotProvisioningCreateCertFromCsrResponse_t;
+
+/**
+ * @ingroup provisioning_datatypes_paramstructs
+ * @brief User-specific callback information for handling server response of the Provisioning CreateCertificateFromCsr
+ * service API.
+ *
+ * @paramfor @ref provisioning_function_registerthing
+ *
+ * Provides a function that is invoked on completion of an @ref AwsIotProvisioning_CreateCertificateFromCsr API
+ * operation.
+ *
+ * @initializer{AwsIotProvisioningCreateCertFromCsrCallbackInfo_t,AWS_IOT_PROVISIONING_CREATE_CERTIFICATE_FROM_CSR_CALLBACK_INFO_INITIALIZER}
+ */
+typedef struct AwsIotProvisioningCreateCertFromCsrCallbackInfo
+{
+    void * userParam; /**< The user-provided parameter that is (as the first parameter) to the callback
+                       * function (optional). */
+
+    /**
+     * @brief User-provided callback function signature.
+     *
+     * @param[in] userContext #AwsIotProvisioningCreateCertFromCsrCallbackInfo_t.userParam
+     * @param[in] serverResponse Parsed server response of either device credentials
+     * or provisioned device information.
+     *
+     * @see #AwsIotProvisioningCreateCertFromCsrResponse_t for more information on the second parameter.
+     */
+    void ( * function )( void * userContext,
+                         const AwsIotProvisioningCreateCertFromCsrResponse_t * serverResponse ); /*<** The user-provided
+                                                                                                  * callback to
+                                                                                                  * invoke; with the
+                                                                                                  *#AwsIotProvisioningCreateCertFromCsrCallbackInfo.userParam
+                                                                                                  * data as the #first
+                                                                                                  * parameter. */
+} AwsIotProvisioningCreateCertFromCsrCallbackInfo_t;
+
+/**
+ * @ingroup provisioning_datatypes_paramstructs
  * @brief Aggregates the data sent as response from AWS IoT Core service for the request to generate new key-pair and
  * certificate for the device.
  *
@@ -316,6 +386,7 @@ typedef struct AwsIotProvisioningCreateKeysAndCertificateResponse
     } u; /**< @brief Valid member depends on operation status. */
 } AwsIotProvisioningCreateKeysAndCertificateResponse_t;
 
+
 /**
  * @ingroup provisioning_datatypes_paramstructs
  * @brief User-specific callback information for handling server response for the Provisioning CreateKeysAndCertificate
@@ -336,19 +407,19 @@ typedef struct AwsIotProvisioningCreateKeysAndCertificateCallbackInfo
     /**
      * @brief User-provided callback function signature.
      *
-     * @param[in] void* #AwsIotProvisioningCreateKeysAndCertificateCallbackInfo_t.userParam
-     * @param[in] AwsIotProvisioningCallbackParam_t* Parsed server response of either device credentials
+     * @param[in] userContext #AwsIotProvisioningCreateKeysAndCertificateCallbackInfo_t.userParam
+     * @param[in] serverResponse Parsed server response of either device credentials
      * or provisioned device information.
      *
      * @see #AwsIotProvisioningCreateKeysAndCertificateResponse_t for more information on the second parameter.
      */
-    void ( * function )( void *,
-                         const AwsIotProvisioningCreateKeysAndCertificateResponse_t * ); /*<** The user-provided
-                                                                                          * callback to
-                                                                                          * invoke; with the
-                                                                                          *#AwsIotProvisioningCreateKeysAndCertificateCallbackInfo.userParam
-                                                                                          * data as the #first
-                                                                                          * parameter. */
+    void ( * function )( void * userContext,
+                         const AwsIotProvisioningCreateKeysAndCertificateResponse_t * serverResponse ); /*<** The user-provided
+                                                                                                         * callback to
+                                                                                                         * invoke; with the
+                                                                                                         *#AwsIotProvisioningCreateKeysAndCertificateCallbackInfo.userParam
+                                                                                                         * data as the #first
+                                                                                                         * parameter. */
 } AwsIotProvisioningCreateKeysAndCertificateCallbackInfo_t;
 
 /**
@@ -409,17 +480,17 @@ typedef struct AwsIotProvisioningRegisterThingCallbackInfo
     /**
      * @brief User-provided callback function signature.
      *
-     * @param[in] void* #AwsIotProvisioningRegisterThingCallbackInfo_t.userParam
-     * @param[in] AwsIotProvisioningRegisterThingResponse_t* Parsed server response of either device credentials
+     * @param[in] userContext #AwsIotProvisioningRegisterThingCallbackInfo_t.userParam
+     * @param[in] serverResponse Parsed server response of either device credentials
      * or provisioned device information.
      *
      * @see #AwsIotProvisioningRegisterThingResponse_t for more information on the second parameter.
      */
-    void ( * function )( void *,
-                         const AwsIotProvisioningRegisterThingResponse_t * ); /*<** The user-provided callback to
-                                                                               * invoke; with the
-                                                                               *#AwsIotProvisioningRegisterThingCallbackInfo.userParam
-                                                                               * data as the #first parameter. */
+    void ( * function )( void * userContext,
+                         const AwsIotProvisioningRegisterThingResponse_t * serverResponse ); /*<** The user-provided callback to
+                                                                                              * invoke; with the
+                                                                                              *#AwsIotProvisioningRegisterThingCallbackInfo.userParam
+                                                                                              * data as the #first parameter. */
 } AwsIotProvisioningRegisterThingCallbackInfo_t;
 
 /*------------------------ Provisioning defined constants -------------------------*/
@@ -427,6 +498,9 @@ typedef struct AwsIotProvisioningRegisterThingCallbackInfo
 /* @[define_provisioning_initializers] */
 #define AWS_IOT_PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_CALLBACK_INFO_INITIALIZER    { 0 } /**< @brief Initializer for
                                                                                              * #AwsIotProvisioningCreateKeysAndCertificateCallbackInfo_t
+                                                                                             **/
+#define AWS_IOT_PROVISIONING_CREATE_CERTIFICATE_FROM_CSR_CALLBACK_INFO_INITIALIZER    { 0 } /**< @brief Initializer for
+                                                                                             * #AwsIotProvisioningCreateCertFromCsrCallbackInfo_t
                                                                                              **/
 #define AWS_IOT_PROVISIONING_REGISTER_THING_CALLBACK_INFO_INITIALIZER                 { 0 } /**< @brief Initializer for
                                                                                              * #AwsIotProvisioningRegisterThingCallbackInfo_t

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
@@ -177,11 +177,11 @@ static bool _checkInit( void )
 static void _commonServerResponseHandler( IotMqttCallbackParam_t * const pPublishData,
                                           _provisioningServerResponseParser responseParser )
 {
-    AwsIotStatus_t responseStatus = AWS_IOT_UNKNOWN;
+    AwsIotStatus_t responseType = AWS_IOT_UNKNOWN;
 
     /* Is a user thread waiting for the result? */
     if( ( _activeOperation.info.userCallback.createKeysAndCertificateCallback.function == NULL ) ||
-        ( _activeOperation.info.userCallback.createCertificateFromCsrCallback.function == NULL ) ||
+        ( _activeOperation.info.userCallback.createCertFromCsrCallback.function == NULL ) ||
         ( _activeOperation.info.userCallback.registerThingCallback.function == NULL ) )
     {
         IotLogDebug( "Received unexpected server response on topic %s.",
@@ -191,10 +191,10 @@ static void _commonServerResponseHandler( IotMqttCallbackParam_t * const pPublis
     else
     {
         /* Determine whether the response from the server is "accepted" or "rejected". */
-        responseStatus = AwsIot_ParseStatus( pPublishData->u.message.pTopicFilter,
-                                             pPublishData->u.message.topicFilterLength );
+        responseType = AwsIot_ParseStatus( pPublishData->u.message.pTopicFilter,
+                                           pPublishData->u.message.topicFilterLength );
 
-        if( responseStatus == AWS_IOT_UNKNOWN )
+        if( responseType == AWS_IOT_UNKNOWN )
         {
             IotLogWarn( "Unknown parsing status on topic %s. Ignoring message.",
                         pPublishData->u.message.pTopicFilter,
@@ -205,7 +205,7 @@ static void _commonServerResponseHandler( IotMqttCallbackParam_t * const pPublis
         {
             /* Parse the server response and execute the user callback. */
             _activeOperation.info.status = responseParser(
-                responseStatus,
+                responseType,
                 pPublishData->u.message.info.pPayload,
                 pPublishData->u.message.info.payloadLength,
                 &_activeOperation.info.userCallback );
@@ -611,7 +611,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
 
         /* Update the operation object to represent an active "Certificate-Signing Request" operation. */
         _provisioningCallbackInfo_t callbackInfo;
-        callbackInfo.createCertificateFromCsrCallback = *pResponseCallback;
+        callbackInfo.createCertFromCsrCallback = *pResponseCallback;
         _setActiveOperation( &callbackInfo );
 
         /* Serialization of request payload occurs in a 2-step process, one for calculation of buffer size, and then,

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
@@ -76,8 +76,26 @@ const IotSerializerDecodeInterface_t * _pAwsIotProvisioningDecoder = NULL;
  * CreateKeysAndCertificate, CreateCertificateFromCsr, RegisterThing.
  */
 static _provisioningOperation_t _activeOperation[ 3 ];
+
+/**
+ * @brief The index reference to the operation object
+ * in #_activeOperation array for the CreateKeysAndCertificate
+ * operation.
+ */
 static const uint8_t _createKeysAndCertOperationIndex = 0;
+
+/**
+ * @brief The index reference to the operation object
+ * in #_activeOperation array for the CreateCertificateFromCsr
+ * operation.
+ */
 static const uint8_t _createCertFromCsrOperationIndex = 1;
+
+/**
+ * @brief The index reference to the operation object
+ * in #_activeOperation array for the RegisterThing
+ * operation.
+ */
 static const uint8_t _registerThingOperationIndex = 2;
 
 /**
@@ -106,7 +124,7 @@ static bool _checkInit( void );
  * @brief Initializes the operation object in #_activeOperation array for the
  * passed index reference.
  *
- * @param[in] The index reference to the operation object instance to initialize.
+ * @param[in] operationIndex The index reference to the operation object instance to initialize.
  *
  * @return Returns #AWS_IOT_PROVISIONING_SUCCESS if initialization is successful;
  * otherwise #AWS_IOT_PROVISIONING_INIT_FAILED.
@@ -117,7 +135,7 @@ static AwsIotProvisioningError_t _initializeOperationObject( uint8_t operationIn
  * @brief Cleans up the operation object in #_activeOperation array for the
  * passed index reference.
  *
- * @param[in] The index reference to the operation object instance to clean-up.
+ * @param[in] operationIndex The index reference to the operation object instance to clean-up.
  */
 static void _cleanUpOperationObject( uint8_t operationIndex );
 
@@ -159,9 +177,10 @@ static void _registerThingResponseReceivedCallback( void * param1,
                                                     IotMqttCallbackParam_t * const pPublish );
 
 /**
- * @brief Sets the active operation object, #_activeOperation, to represent an active operation in progress.
+ * @brief Sets an operation object in the #_activeOperation array to represent
+ * an active operation in progress.
  * @param[in] operationIndex The index reference to the ongoing operation
- * in #_activeOperation object.
+ * object in the #_activeOperation array.
  * @param[in] pUserCallback The user-provided callback information that will be copied
  * to the active operation object.
  */
@@ -171,7 +190,10 @@ static void _setActiveOperation( uint8_t operationIndex,
 /**
  * @brief Waits for server response within the provided timeout period, and returns the result of the wait operation.
  *
- * @param timeoutMs The time period (in milliseconds) to wait for server response.
+ * @param[in] operationIndex The index reference to the ongoing operation
+ * object in the #_activeOperation array.
+ * @param[in] timeoutMs The time period (in milliseconds) to wait for server response.
+ *
  * @return Returns #AWS_IOT_PROVISIONING_SUCCESS if a server response is received within the @p timeoutMs period; otherwise returns
  * #AWS_IOT_PROVISIONING_TIMEOUT
  */
@@ -322,7 +344,7 @@ static void _commonServerResponseHandler( const uint8_t operationIndex,
     {
         IotLogWarn( "api: Unexpected invocation of subscription callback: "
                     "Clean-up on library was already called: OperationIndex={%d}",
-                    operationIndex )
+                    operationIndex );
     }
 
     /* Decrement the operation's semaphore reference count, as we don't need

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
@@ -703,7 +703,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
 
     if( connection == NULL )
     {
-        IotLogError( "Bad parameter: MQTT connection is not initialized: Operation={%s}",
+        IotLogError( "Bad parameter: MQTT connection is not initialized: Operation={\"%s\"}",
                      CREATE_CERT_FROM_CSR_OPERATION_LOG );
 
         status = AWS_IOT_PROVISIONING_BAD_PARAMETER;
@@ -711,7 +711,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
     else if( ( pCertificateSigningRequest == NULL ) || ( csrLength == 0 ) )
     {
         IotLogError( "Bad parameter: Invalid Certificate-Signing Request: "
-                     "Operation={%s}", CREATE_CERT_FROM_CSR_OPERATION_LOG );
+                     "Operation={\"%s\"}", CREATE_CERT_FROM_CSR_OPERATION_LOG );
 
         status = AWS_IOT_PROVISIONING_BAD_PARAMETER;
     }
@@ -720,7 +720,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
              ( pResponseCallback->function == NULL ) )
     {
         IotLogError(
-            "Bad parameter: Invalid callback provided: Operation={%s}",
+            "Bad parameter: Invalid callback provided: Operation={\"%s\"}",
             CREATE_CERT_FROM_CSR_OPERATION_LOG );
 
         status = AWS_IOT_PROVISIONING_BAD_PARAMETER;
@@ -733,7 +733,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
 
         if( mqttOpResult != IOT_MQTT_SUCCESS )
         {
-            IotLogError( "Failed to subscribe to response topics: Operation={%s}, MQTTError={%s}",
+            IotLogError( "Failed to subscribe to response topics: Operation={\"%s\"}, MQTTError={%s}",
                          CREATE_CERT_FROM_CSR_OPERATION_LOG,
                          IotMqtt_strerror( mqttOpResult ) );
             status = AWS_IOT_PROVISIONING_MQTT_ERROR;
@@ -742,7 +742,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
 
     if( status == AWS_IOT_PROVISIONING_SUCCESS )
     {
-        IotLogDebug( "Subscribed to response topics: Operation={%s}",
+        IotLogDebug( "Subscribed to response topics: Operation={\"%s\"}",
                      CREATE_CERT_FROM_CSR_OPERATION_LOG );
 
         /* Update the operation object to represent an active "Certificate-Signing Request" operation. */
@@ -760,7 +760,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
         if( status != AWS_IOT_PROVISIONING_SUCCESS )
         {
             IotLogError( "Unable to create PUBLISH payload: Failed to calculate size of payload: "
-                         "Operation={%s}", CREATE_CERT_FROM_CSR_OPERATION_LOG );
+                         "Operation={\"%s\"}", CREATE_CERT_FROM_CSR_OPERATION_LOG );
         }
     }
 
@@ -774,7 +774,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
         if( pPayloadBuffer == NULL )
         {
             IotLogError( "Unable to create PUBLISH payload: Memory allocation for payload failed: "
-                         "Operation={%s}",
+                         "Operation={\"%s\"}",
                          REGISTER_THING_OPERATION_LOG );
             status = AWS_IOT_PROVISIONING_NO_MEMORY;
         }
@@ -791,7 +791,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
         if( status != AWS_IOT_PROVISIONING_SUCCESS )
         {
             IotLogError( "Unable to PUBLISH to request topic: Failed to serialize PUBLISH payload in buffer: "
-                         "Operation={%s}",
+                         "Operation={\"%s\"}",
                          CREATE_CERT_FROM_CSR_OPERATION_LOG );
         }
     }
@@ -806,7 +806,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
         publishInfo.pTopicName = PROVISIONING_CREATE_CERT_FROM_CSR_REQUEST_TOPIC;
         publishInfo.topicNameLength = PROVISIONING_CREATE_CERT_FROM_CSR_REQUEST_TOPIC_LENGTH;
 
-        IotLogDebug( "About to send request to server. Topic={%.*s}, Operation={%s}",
+        IotLogDebug( "About to send request to server. Topic={%.*s}, Operation={\"%s\"}",
                      publishInfo.topicNameLength,
                      publishInfo.pTopicName,
                      CREATE_CERT_FROM_CSR_OPERATION_LOG );
@@ -820,7 +820,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
         if( mqttOpResult != IOT_MQTT_SUCCESS )
         {
             IotLogError( "Failed to PUBLISH to request topic: "
-                         "Topic={%.*s}, Operation={%s}, MQTTError={%s}",
+                         "Topic={%.*s}, Operation={\"%s\"}, MQTTError={%s}",
                          publishInfo.topicNameLength,
                          publishInfo.pTopicName,
                          CREATE_KEYS_AND_CERTIFICATE_OPERATION_LOG,
@@ -831,7 +831,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
 
     if( status == AWS_IOT_PROVISIONING_SUCCESS )
     {
-        IotLogDebug( "Published to request topic: Operation={%s}",
+        IotLogDebug( "Published to request topic: Operation={\"%s\"}",
                      CREATE_CERT_FROM_CSR_OPERATION_LOG );
 
         /* Wait for response from server using the given timeout period. */
@@ -840,7 +840,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
 
         if( status == AWS_IOT_PROVISIONING_TIMEOUT )
         {
-            IotLogDebug( "Operation timed out waiting for server response: Operation={%s}",
+            IotLogDebug( "Operation timed out waiting for server response: Operation={\"%s\"}",
                          CREATE_CERT_FROM_CSR_OPERATION_LOG );
         }
 
@@ -851,7 +851,7 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
         AwsIotProvisioning_FreePayload( pPayloadBuffer );
     }
 
-    IotLogInfo( "Operation is complete: Operation={%s}",
+    IotLogInfo( "Operation is complete: Operation={\"%s\"}",
                 CREATE_CERT_FROM_CSR_OPERATION_LOG );
 
     return status;

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
@@ -38,6 +38,7 @@
 
 /* Platform layer includes. */
 #include "platform/iot_threads.h"
+#include "iot_atomic.h"
 
 /* MQTT API include */
 #include "iot_mqtt.h"
@@ -303,7 +304,7 @@ static void _commonServerResponseHandler( const uint8_t operationIndex,
 
         /* Is a user thread waiting for the result? */
         if( ( pCallbackInfo->createKeysAndCertificateCallback.function == NULL ) ||
-            ( pCallbackInfo->createCertificateFromCsrCallback.function == NULL ) ||
+            ( pCallbackInfo->createCertFromCsrCallback.function == NULL ) ||
             ( pCallbackInfo->registerThingCallback.function == NULL ) )
         {
             IotLogDebug( "Received unexpected server response on topic %s.",

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_api.c
@@ -761,10 +761,10 @@ AwsIotProvisioningError_t AwsIotProvisioning_CreateCertificateFromCsr( IotMqttCo
     if( status == AWS_IOT_PROVISIONING_SUCCESS )
     {
         /* Actual serialization in payload buffer. */
-        status = _AwsIotProvisioning_SerializeCreateCertificateFromCsrRequestPayload( pCertificateSigningRequest,
-                                                                                      csrLength,
-                                                                                      pPayloadBuffer,
-                                                                                      &payloadSize );
+        status = _AwsIotProvisioning_SerializeCreateCertFromCsrRequestPayload( pCertificateSigningRequest,
+                                                                               csrLength,
+                                                                               pPayloadBuffer,
+                                                                               payloadSize );
 
         if( status != AWS_IOT_PROVISIONING_SUCCESS )
         {

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
@@ -84,7 +84,8 @@ static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoder
 /**
  * @brief Common utility for parsing the Certificate PEM string, Certificate ID,
  * and Ownership token data from the server response.
- * These elements are common in the server responses of the MQTT CreateKeysAndCertificate
+ *
+ * @note These elements are common in the server responses of the MQTT CreateKeysAndCertificate
  * and CreateCertificateFromCsr APIs.
  *
  * @param[in] pPayloadDecoder The decoder object that represents the

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
@@ -158,7 +158,7 @@ static AwsIotProvisioningError_t _parseRejectedResponse( IotSerializerDecoderObj
                                            &errorCodeDecoder ) != IOT_SERIALIZER_SUCCESS )
     {
         IotLogError( "Cannot find entry for \"%s\" in response from server of %s operation.",
-                     PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_PEM_STRING,
+                     PROVISIONING_REJECTED_RESPONSE_ERROR_CODE_STRING,
                      pOperationName );
         IOT_SET_AND_GOTO_CLEANUP( AWS_IOT_PROVISIONING_BAD_RESPONSE );
     }

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
@@ -74,7 +74,7 @@ static AwsIotProvisioningError_t _parseRejectedResponse( IotSerializerDecoderObj
  *
  * @return Returns #AWS_IOT_PROVISIONING_SUCCESS if parsing is successful; otherwise
  * #AWS_IOT_PROVISIONING_BAD_RESPONSE if any of the expected data entries is missing
- * in the payload OR @AWS_IOT_PROVISIONING_INTERNAL_FAILURE for decoder failures.
+ * in the payload OR #AWS_IOT_PROVISIONING_INTERNAL_FAILURE for decoder failures.
  */
 static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoderObject_t * pPayloadDecoder,
                                                             IotSerializerDecoderObject_t * pPayloadEntryDecoder,
@@ -100,7 +100,7 @@ static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoder
  *
  * @return Returns #AWS_IOT_PROVISIONING_SUCCESS if parsing is successful; otherwise
  * #AWS_IOT_PROVISIONING_BAD_RESPONSE if any of the expected data entries is missing
- * in the payload OR @AWS_IOT_PROVISIONING_INTERNAL_FAILURE for decoder failures.
+ * in the payload OR #AWS_IOT_PROVISIONING_INTERNAL_FAILURE for decoder failures.
  */
 static AwsIotProvisioningError_t _parseCommonCertInfoInResponse( IotSerializerDecoderObject_t * pPayloadDecoder,
                                                                  IotSerializerDecoderObject_t * pCertPemDecoder,
@@ -237,6 +237,11 @@ static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoder
     }
     else if( serializerStatus != IOT_SERIALIZER_SUCCESS )
     {
+        IotLogError( "parser: Unable to parse server response: "
+                     "Decoder returned failure in searching key entry:"
+                     "Key={\"%s\"}: Operation={%s}",
+                     pKeyString,
+                     pOperationString );
         status = AWS_IOT_PROVISIONING_INTERNAL_FAILURE;
     }
     else if( pPayloadEntryDecoder->type != IOT_SERIALIZER_SCALAR_TEXT_STRING )

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
@@ -231,7 +231,7 @@ static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoder
     {
         /* Entry not found in the payload map. */
         IotLogError( "parser: Unable to parse server response: Key entry not found in response:"
-                     "ExpectedKey={\"%s\"}: Operation={%s}",
+                     "ExpectedKey={\"%s\"}: Operation={\"%s\"}",
                      pKeyString,
                      pOperationString );
         status = AWS_IOT_PROVISIONING_BAD_RESPONSE;
@@ -240,7 +240,7 @@ static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoder
     {
         IotLogError( "parser: Unable to parse server response: "
                      "Decoder returned failure in searching key entry:"
-                     "Key={\"%s\"}: Operation={%s}",
+                     "Key={\"%s\"}: Operation={\"%s\"}",
                      pKeyString,
                      pOperationString );
         status = AWS_IOT_PROVISIONING_INTERNAL_FAILURE;
@@ -249,7 +249,7 @@ static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoder
     {
         IotLogError(
             "parser: Unable to parse server response: Invalid value type of key entry in payload: "
-            "Expected type is text string: Key={\"%s\"}, Operation={%s}",
+            "Expected type is text string: Key={\"%s\"}, Operation={\"%s\"}",
             pKeyString,
             pOperationString );
         status = AWS_IOT_PROVISIONING_BAD_RESPONSE;
@@ -455,7 +455,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseCsrResponse( AwsIotStatus_t r
     {
         /* Decoder object initialization failed */
         IotLogError(
-            "parser: Unable to parser response: Failed to initialize decoder: Operation={%s}",
+            "parser: Unable to parser response: Failed to initialize decoder: Operation={\"%s\"}",
             CREATE_CERT_FROM_CSR_OPERATION_LOG );
         status = AWS_IOT_PROVISIONING_INTERNAL_FAILURE;
     }
@@ -463,7 +463,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseCsrResponse( AwsIotStatus_t r
     {
         IotLogError(
             "parser: Unable to parse server response: Payload format is invalid: "
-            "Expected format is map container: Operation={%s}.",
+            "Expected format is map container: Operation={\"%s\"}.",
             CREATE_CERT_FROM_CSR_OPERATION_LOG );
         status = AWS_IOT_PROVISIONING_BAD_RESPONSE;
     }
@@ -472,7 +472,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseCsrResponse( AwsIotStatus_t r
     {
         if( responseType == AWS_IOT_ACCEPTED )
         {
-            IotLogInfo( "parser: Server has ACCEPTED the operation request: Operation={%s}",
+            IotLogInfo( "parser: Server has ACCEPTED the operation request: Operation={\"%s\"}",
                         CREATE_CERT_FROM_CSR_OPERATION_LOG );
 
             status = _parseCommonCertInfoInResponse( &payloadDecoder,
@@ -502,7 +502,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseCsrResponse( AwsIotStatus_t r
                     ownershipTokenDecoder.u.value.u.string.length;
 
                 /* Invoke the user-provided callback with the parsed credentials data . */
-                IotLogInfo( "parser: About to call user-callback with accepted server response: Operation={%s}",
+                IotLogInfo( "parser: About to call user-callback with accepted server response: Operation={\"%s\"}",
                             CREATE_CERT_FROM_CSR_OPERATION_LOG );
                 userCallbackInfo->createCertFromCsrCallback.function( userCallbackInfo->createCertFromCsrCallback.userParam,
                                                                       &serverResponse );
@@ -515,7 +515,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseCsrResponse( AwsIotStatus_t r
         }
         else if( responseType == AWS_IOT_REJECTED )
         {
-            IotLogWarn( "parser: Server has REJECTED the operation request: Operation={%s}",
+            IotLogWarn( "parser: Server has REJECTED the operation request: Operation={\"%s\"}",
                         CREATE_CERT_FROM_CSR_OPERATION_LOG );
 
             status = _parseRejectedResponse( &payloadDecoder,
@@ -526,7 +526,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseCsrResponse( AwsIotStatus_t r
             /* Invoke the user-provided callback with the parsed rejected data, if parsing was successful . */
             if( status == AWS_IOT_PROVISIONING_SUCCESS )
             {
-                IotLogInfo( "parser: About to call user-callback with rejected server response: Operation={%s}",
+                IotLogInfo( "parser: About to call user-callback with rejected server response: Operation={\"%s\"}",
                             CREATE_CERT_FROM_CSR_OPERATION_LOG );
                 userCallbackInfo->createCertFromCsrCallback.function( userCallbackInfo->createCertFromCsrCallback.userParam,
                                                                       &serverResponse );

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
@@ -73,8 +73,8 @@ static AwsIotProvisioningError_t _parseRejectedResponse( IotSerializerDecoderObj
  * #AWS_IOT_PROVISIONING_BAD_RESPONSE if any of the expected data entries is missing
  * in the payload OR @AWS_IOT_PROVISIONING_INTERNAL_FAILURE for decoder failures.
  */
-static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoderObject_t * payloadDecoder,
-                                                            IotSerializerDecoderObject_t * payloadEntryDecoder,
+static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoderObject_t * pPayloadDecoder,
+                                                            IotSerializerDecoderObject_t * pPayloadEntryDecoder,
                                                             const char * pKeyString,
                                                             const char * pOperationString );
 
@@ -97,10 +97,10 @@ static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoder
  * #AWS_IOT_PROVISIONING_BAD_RESPONSE if any of the expected data entries is missing
  * in the payload OR @AWS_IOT_PROVISIONING_INTERNAL_FAILURE for decoder failures.
  */
-static AwsIotProvisioningError_t _parseCommonCertInfoInResponse( IotSerializerDecoderObject_t * payloadDecoder,
-                                                                 IotSerializerDecoderObject_t * certPemDecoder,
-                                                                 IotSerializerDecoderObject_t * certIdDecoder,
-                                                                 IotSerializerDecoderObject_t * ownershipTokenDecoder,
+static AwsIotProvisioningError_t _parseCommonCertInfoInResponse( IotSerializerDecoderObject_t * pPayloadDecoder,
+                                                                 IotSerializerDecoderObject_t * pCertPemDecoder,
+                                                                 IotSerializerDecoderObject_t * pCertIdDecoder,
+                                                                 IotSerializerDecoderObject_t * pOwnershipTokenDecoder,
                                                                  const char * pOperationString );
 
 
@@ -200,13 +200,13 @@ static AwsIotProvisioningError_t _parseRejectedResponse( IotSerializerDecoderObj
 
 /*------------------------------------------------------------------*/
 
-static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoderObject_t * payloadDecoder,
-                                                            IotSerializerDecoderObject_t * payloadEntryDecoder,
+static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoderObject_t * pPayloadDecoder,
+                                                            IotSerializerDecoderObject_t * pPayloadEntryDecoder,
                                                             const char * pKeyString,
                                                             const char * pOperationString )
 {
-    AwsIotProvisioning_Assert( payloadDecoder != NULL );
-    AwsIotProvisioning_Assert( payloadEntryDecoder != NULL );
+    AwsIotProvisioning_Assert( pPayloadDecoder != NULL );
+    AwsIotProvisioning_Assert( pPayloadEntryDecoder != NULL );
     AwsIotProvisioning_Assert( pKeyString != NULL );
     AwsIotProvisioning_Assert( pOperationString != NULL );
 
@@ -214,9 +214,9 @@ static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoder
     IotSerializerError_t serializerStatus = IOT_SERIALIZER_SUCCESS;
 
     /* Look for the data entry in the map. */
-    serializerStatus = _pAwsIotProvisioningDecoder->find( payloadDecoder,
+    serializerStatus = _pAwsIotProvisioningDecoder->find( pPayloadDecoder,
                                                           pKeyString,
-                                                          payloadEntryDecoder );
+                                                          pPayloadEntryDecoder );
 
     if( serializerStatus == IOT_SERIALIZER_NOT_FOUND )
     {
@@ -231,7 +231,7 @@ static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoder
     {
         status = AWS_IOT_PROVISIONING_INTERNAL_FAILURE;
     }
-    else if( payloadEntryDecoder->type != IOT_SERIALIZER_SCALAR_TEXT_STRING )
+    else if( pPayloadEntryDecoder->type != IOT_SERIALIZER_SCALAR_TEXT_STRING )
     {
         IotLogError(
             "parser: Unable to parse server response: Invalid value type of key entry in payload: "

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
@@ -210,6 +210,9 @@ static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoder
                                                             const char * pKeyString,
                                                             const char * pOperationString )
 {
+    /* Suppress unused parameter compiler warning. */
+    ( void ) pOperationString;
+
     AwsIotProvisioning_Assert( pPayloadDecoder != NULL );
     AwsIotProvisioning_Assert( pPayloadEntryDecoder != NULL );
     AwsIotProvisioning_Assert( pKeyString != NULL );

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
@@ -46,11 +46,13 @@
 /**
  * @brief Parses the rejected response payload received from the server, and populates the data of the passed
  * @a pResponseData parameter.
+ *
  * @param[in] pPayloadDecoder The outermost decoder object representing the response payload.
  * @param[in] pOperationName The Provisioning library operation (or API) that the response is associated with.
  * @param[out] pResponseData This will be populated with the data parsed from the response payload, if successful.
  * @param[out] pStatusCode This will be populated with the error status code parsed from the response payload,
  * if successful.
+ *
  * @return #AWS_IOT_PROVISIONING_SUCCESS, if parsing is successful; otherwise appropriate error message.
  */
 static AwsIotProvisioningError_t _parseRejectedResponse( IotSerializerDecoderObject_t * pPayloadDecoder,
@@ -69,6 +71,7 @@ static AwsIotProvisioningError_t _parseRejectedResponse( IotSerializerDecoderObj
  * @param[in] pKeyString The key string to parse from the payload.
  * @param[in] pOperationString The string of the ongoing operation to use for
  * logging.
+ *
  * @return Returns #AWS_IOT_PROVISIONING_SUCCESS if parsing is successful; otherwise
  * #AWS_IOT_PROVISIONING_BAD_RESPONSE if any of the expected data entries is missing
  * in the payload OR @AWS_IOT_PROVISIONING_INTERNAL_FAILURE for decoder failures.
@@ -83,6 +86,7 @@ static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoder
  * and Ownership token data from the server response.
  * These elements are common in the server responses of the MQTT CreateKeysAndCertificate
  * and CreateCertificateFromCsr APIs.
+ *
  * @param[in] payloadDecoder The decoder object that represents the
  * server response payload as a map container.
  * @param[in/out] certPemDecoder The decoder object to store the parsed Certificate
@@ -93,6 +97,7 @@ static AwsIotProvisioningError_t _parseKeyedEntryInPayload( IotSerializerDecoder
  * Certificate Ownership Token string in.
  * @param[in] pOperationString The string of the ongoing operation to use for
  * logging.
+ *
  * @return Returns #AWS_IOT_PROVISIONING_SUCCESS if parsing is successful; otherwise
  * #AWS_IOT_PROVISIONING_BAD_RESPONSE if any of the expected data entries is missing
  * in the payload OR @AWS_IOT_PROVISIONING_INTERNAL_FAILURE for decoder failures.
@@ -266,7 +271,7 @@ static AwsIotProvisioningError_t _parseCommonCertInfoInResponse( IotSerializerDe
     /* Look for the certificate PEM data. */
     status = _parseKeyedEntryInPayload( pPayloadDecoder,
                                         pCertPemDecoder,
-                                        PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_PEM_STRING,
+                                        PROVISIONING_SERVER_RESPONSE_PAYLOAD_CERTIFICATE_PEM_STRING,
                                         pOperationString );
 
     if( status == AWS_IOT_PROVISIONING_SUCCESS )
@@ -274,7 +279,7 @@ static AwsIotProvisioningError_t _parseCommonCertInfoInResponse( IotSerializerDe
         /* Look for the certificate ID data. */
         status = _parseKeyedEntryInPayload( pPayloadDecoder,
                                             pCertIdDecoder,
-                                            PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_ID_STRING,
+                                            PROVISIONING_SERVER_RESPONSE_PAYLOAD_CERTIFICATE_ID_STRING,
                                             pOperationString );
     }
 
@@ -283,7 +288,7 @@ static AwsIotProvisioningError_t _parseCommonCertInfoInResponse( IotSerializerDe
         /* Look for the certificate ownership token data. */
         status = _parseKeyedEntryInPayload( pPayloadDecoder,
                                             pOwnershipTokenDecoder,
-                                            PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_TOKEN_KEY_STRING,
+                                            PROVISIONING_SERVER_RESPONSE_PAYLOAD_CERTIFICATE_TOKEN_KEY_STRING,
                                             pOperationString );
     }
 

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
@@ -199,8 +199,8 @@ static AwsIotProvisioningError_t _parseCommonCertInfoInResponse( IotSerializerDe
     if( serializerStatus == IOT_SERIALIZER_NOT_FOUND )
     {
         /* Cannot find "certificatePem" */
-        IotLogError( "parser: Unable to parse server Payload container encoding is invalid: "
-                     "Expected container type is map: Operation={%s}}",
+        IotLogError( "parser: Unable to parse server response: Key entry not found in response:"
+                     "ExpectedKey={\"%s\"}: Operation={%s}",
                      PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_PEM_STRING,
                      CREATE_KEYS_AND_CERTIFICATE_OPERATION_LOG );
         status = AWS_IOT_PROVISIONING_BAD_RESPONSE;
@@ -212,12 +212,15 @@ static AwsIotProvisioningError_t _parseCommonCertInfoInResponse( IotSerializerDe
     else if( certPemDecoder->type != IOT_SERIALIZER_SCALAR_TEXT_STRING )
     {
         IotLogError(
-            "parser: Unable to parse server Payload container encoding is invalid: "
-            "Expected container type is map: Operation={%s}: "
-            "Key={\"%s\"}, Operation={%s}",
+            "parser: Unable to parse server response: Invalid value type of key entry in payload: "
+            "Expected type is text string: Key={\"%s\"}, Operation={%s}",
             PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_PEM_STRING,
             CREATE_KEYS_AND_CERTIFICATE_OPERATION_LOG );
         status = AWS_IOT_PROVISIONING_BAD_RESPONSE;
+    }
+    else
+    {
+        /* Nothing to do. */
     }
 
     if( status == AWS_IOT_PROVISIONING_SUCCESS )
@@ -230,9 +233,8 @@ static AwsIotProvisioningError_t _parseCommonCertInfoInResponse( IotSerializerDe
         if( serializerStatus == IOT_SERIALIZER_NOT_FOUND )
         {
             /* Cannot find "certificateId" */
-            IotLogError( "parser: Unable to parse server response: Payload container encoding is invalid: "
-                         "Expected container type is map: Operation={%s}p:"
-                         " ExpectedKey={\"%s\"}: Operation={%s}",
+            IotLogError( "parser: Unable to parse server response: Key entry not found in response:"
+                         "ExpectedKey={\"%s\"}: Operation={%s}",
                          PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_ID_STRING,
                          CREATE_KEYS_AND_CERTIFICATE_OPERATION_LOG );
             status = AWS_IOT_PROVISIONING_BAD_RESPONSE;
@@ -244,8 +246,7 @@ static AwsIotProvisioningError_t _parseCommonCertInfoInResponse( IotSerializerDe
         else if( certIdDecoder->type != IOT_SERIALIZER_SCALAR_TEXT_STRING )
         {
             IotLogError(
-                "parser: Unable to parse server response: Invalid Payload container encoding is invalid: "
-                "Expected container type is map: Operation={%s}: "
+                "parser: Unable to parse server response: Invalid value type of key entry in payload: "
                 "Expected type is text string: Key={\"%s\"}, Operation={%s}",
                 PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_ID_STRING,
                 CREATE_KEYS_AND_CERTIFICATE_OPERATION_LOG );
@@ -263,9 +264,8 @@ static AwsIotProvisioningError_t _parseCommonCertInfoInResponse( IotSerializerDe
         if( serializerStatus == IOT_SERIALIZER_NOT_FOUND )
         {
             /* Cannot find "certificate ownership token" */
-            IotLogError( "parser: Unable to parse server response: Payload container encoding is invalid: "
-                         "Expected container type is map: Operation={%s}p:"
-                         " ExpectedKey={\"%s\"}: Operation={%s}",
+            IotLogError( "parser: Unable to parse server response: Key entry not found in response:"
+                         "ExpectedKey={\"%s\"}: Operation={%s}",
                          PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_TOKEN_KEY_STRING,
                          CREATE_KEYS_AND_CERTIFICATE_OPERATION_LOG );
             status = AWS_IOT_PROVISIONING_BAD_RESPONSE;
@@ -277,8 +277,7 @@ static AwsIotProvisioningError_t _parseCommonCertInfoInResponse( IotSerializerDe
         else if( ownershipTokenDecoder->type != IOT_SERIALIZER_SCALAR_TEXT_STRING )
         {
             IotLogError(
-                "parser: Unable to parse server response: Invalid Payload container encoding is invalid: "
-                "Expected container type is map: Operation={%s}: "
+                "parser: Unable to parse server response: Invalid value type of key entry in payload: "
                 "Expected type is text string: Key={\"%s\"}, Operation={%s}",
                 PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_TOKEN_KEY_STRING,
                 CREATE_KEYS_AND_CERTIFICATE_OPERATION_LOG );
@@ -348,7 +347,8 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseKeysAndCertificateResponse( A
                                                    &privateKeyDecoder ) != IOT_SERIALIZER_SUCCESS )
             {
                 /* Cannot find "private key" */
-                IotLogError( "Cannot find entry for \"%s\" in response from server of %s operation.",
+                IotLogError( "parser: Unable to parse server response: Key entry not found in response:"
+                             "ExpectedKey={\"%s\"}: Operation={%s}",
                              PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_PRIVATE_KEY_STRING,
                              CREATE_KEYS_AND_CERTIFICATE_OPERATION_LOG );
                 IOT_SET_AND_GOTO_CLEANUP( AWS_IOT_PROVISIONING_BAD_RESPONSE );
@@ -356,10 +356,10 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseKeysAndCertificateResponse( A
 
             if( privateKeyDecoder.type != IOT_SERIALIZER_SCALAR_TEXT_STRING )
             {
-                IotLogError(
-                    "Invalid value type of \"%s\" data in server response of %s operation. Expected type is text string.",
-                    PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_PRIVATE_KEY_STRING,
-                    CREATE_KEYS_AND_CERTIFICATE_OPERATION_LOG );
+                "parser: Unable to parse server response: Invalid value type of key entry in payload: "
+                "Expected type is text string: Key={\"%s\"}, Operation={%s}",
+                PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_PRIVATE_KEY_STRING,
+                CREATE_KEYS_AND_CERTIFICATE_OPERATION_LOG );
                 IOT_SET_AND_GOTO_CLEANUP( AWS_IOT_PROVISIONING_BAD_RESPONSE );
             }
 
@@ -456,8 +456,8 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseCsrResponse( AwsIotStatus_t r
     else if( payloadDecoder.type != IOT_SERIALIZER_CONTAINER_MAP )
     {
         IotLogError(
-            "parser: Unable to parse server response: Payload container encoding is invalid: "
-            "Expected container type is map: Operation={%s}.",
+            "parser: Unable to parse server response: Payload format is invalid: "
+            "Expected format is map container: Operation={%s}.",
             CREATE_CERT_FROM_CSR_OPERATION_LOG );
         status = AWS_IOT_PROVISIONING_BAD_RESPONSE;
     }

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_parser.c
@@ -334,6 +334,21 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseKeysAndCertificateResponse( A
 
 /*------------------------------------------------------------------*/
 
+AwsIotProvisioningError_t _AwsIotProvisioning_ParseCsrResponse( AwsIotStatus_t responseType,
+                                                                const void * pResponsePayload,
+                                                                size_t payloadLength,
+                                                                const _provisioningCallbackInfo_t * userCallbackInfo )
+{
+    ( void ) responseType;
+    ( void ) pResponsePayload;
+    ( void ) payloadLength;
+    ( void ) userCallbackInfo;
+
+    return AWS_IOT_PROVISIONING_SUCCESS;
+}
+
+/*------------------------------------------------------------------*/
+
 AwsIotProvisioningError_t _AwsIotProvisioning_ParseRegisterThingResponse( AwsIotStatus_t responseType,
                                                                           const void * pResponsePayload,
                                                                           size_t responsePayloadLength,

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_serializer.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_serializer.c
@@ -180,7 +180,7 @@ static AwsIotProvisioningError_t _serializeCreateKeysAndCertificateRequestPayloa
     /* Encode an empty map container (Diagnostic notation as "{}"") .*/
     serializerStatus = _pAwsIotProvisioningEncoder->openContainer( pOutermostEncoder,
                                                                    &emptyPayloadEncoder,
-                                                                   _numCertFromCsrMapEntries );
+                                                                   _numKeysAndCertMapEntries );
 
     /* Close the map. */
     if( checkSerializerStatus( _pAwsIotProvisioningEncoder->

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_serializer.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_serializer.c
@@ -432,14 +432,14 @@ AwsIotProvisioningError_t _serializeCertFromCsrPayload( const char * pCertificat
     if( serializerResult == IOT_SERIALIZER_OUT_OF_MEMORY )
     {
         IotLogError( "serializer: Unable to serialize request payload: "
-                     "Failed to allocate memory for map container: Operation={%s}",
+                     "Failed to allocate memory for map container: Operation={\"%s\"}",
                      CREATE_CERT_FROM_CSR_OPERATION_LOG );
         status = AWS_IOT_PROVISIONING_NO_MEMORY;
     }
     else if( isSuccessStatus( serializerResult ) == false )
     {
         IotLogError( "serializer: Unable to serialize request payload: "
-                     "Failed to open map container: Operation={%s}",
+                     "Failed to open map container: Operation={\"%s\"}",
                      CREATE_CERT_FROM_CSR_OPERATION_LOG );
         status = AWS_IOT_PROVISIONING_INTERNAL_FAILURE;
     }
@@ -458,7 +458,7 @@ AwsIotProvisioningError_t _serializeCertFromCsrPayload( const char * pCertificat
 
         {
             IotLogError( "serializer: Unable to serialize request payload: "
-                         "Failed to insert CSR entry in map: Operation={%s}",
+                         "Failed to insert CSR entry in map: Operation={\"%s\"}",
                          CREATE_CERT_FROM_CSR_OPERATION_LOG );
             status = AWS_IOT_PROVISIONING_INTERNAL_FAILURE;
         }
@@ -471,7 +471,7 @@ AwsIotProvisioningError_t _serializeCertFromCsrPayload( const char * pCertificat
                                                                           &mapEncoder ) ) == false )
         {
             IotLogError( "serializer: Unable to serialize request payload: "
-                         "Failed to close map container: Operation={%s}",
+                         "Failed to close map container: Operation={\"%s\"}",
                          CREATE_CERT_FROM_CSR_OPERATION_LOG );
             status = AWS_IOT_PROVISIONING_INTERNAL_FAILURE;
         }
@@ -498,7 +498,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_CalculateCertFromCsrPayloadSize( c
                                            0 ) != IOT_SERIALIZER_SUCCESS )
     {
         IotLogError( "serializer: Unable to serialize request payload: "
-                     "Failed to initialize encoder: Operation={%s}",
+                     "Failed to initialize encoder: Operation={\"%s\"}",
                      CREATE_CERT_FROM_CSR_OPERATION_LOG );
         status = AWS_IOT_PROVISIONING_INTERNAL_FAILURE;
     }
@@ -518,7 +518,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_CalculateCertFromCsrPayloadSize( c
         *pPayloadSize = _pAwsIotProvisioningEncoder->getExtraBufferSizeNeeded( &outerEncoder );
         AwsIotProvisioning_Assert( *pPayloadSize != 0 );
         IotLogDebug( "serializer: Calculated serialization size and populated in output parameter: "
-                     "Operation={%s}",
+                     "Operation={\"%s\"}",
                      CREATE_CERT_FROM_CSR_OPERATION_LOG );
     }
 
@@ -548,7 +548,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateCertFromCsrRequestP
                                            bufferSize ) != IOT_SERIALIZER_SUCCESS )
     {
         IotLogError( "serializer: Unable to serialize request payload: "
-                     "Failed to initialize encoder: Operation={%s}",
+                     "Failed to initialize encoder: Operation={\"%s\"}",
                      CREATE_CERT_FROM_CSR_OPERATION_LOG );
         status = AWS_IOT_PROVISIONING_INTERNAL_FAILURE;
     }

--- a/libraries/aws/provisioning/src/aws_iot_provisioning_serializer.c
+++ b/libraries/aws/provisioning/src/aws_iot_provisioning_serializer.c
@@ -355,6 +355,34 @@ AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateKeysAndCertificateR
 
 /*------------------------------------------------------------------*/
 
+AwsIotProvisioningError_t _AwsIotProvisioning_CalculateCertFromCsrPayloadSize( const char * pCertificateSigningRequest,
+                                                                               size_t csrLength,
+                                                                               size_t * pPayloadSize )
+{
+    ( void ) pCertificateSigningRequest;
+    ( void ) csrLength;
+    ( void ) pPayloadSize;
+
+    return true;
+}
+
+/*------------------------------------------------------------------*/
+
+AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateCertificateFromCsrRequestPayload( const char * pCertificateSigningRequest,
+                                                                                               size_t csrLength,
+                                                                                               uint8_t * pSerializationBuffer,
+                                                                                               size_t * pBufferSize )
+{
+    ( void ) pCertificateSigningRequest;
+    ( void ) csrLength;
+    ( void ) pSerializationBuffer;
+    ( void ) pBufferSize;
+
+    return true;
+}
+
+/*------------------------------------------------------------------*/
+
 AwsIotProvisioningError_t _AwsIotProvisioning_SerializeRegisterThingRequestPayload( const AwsIotProvisioningRegisterThingRequestInfo_t * pRequestData,
                                                                                     uint8_t ** pSerializationBuffer,
                                                                                     size_t * pBufferSize )

--- a/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
+++ b/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
@@ -295,6 +295,12 @@
     ( ( uint16_t ) ( sizeof( PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_REQUEST_TOPIC ) - 1 ) )
 
 /**
+ * @brief The key string for Certificate-Singing Request value in the request payload
+ * to the MQTT CreateCertificateFromCsr service API.
+ */
+#define PROVISIONING_CREATE_CERT_FROM_CSR_REQUEST_PAYLOAD_PEM_STRING                              "certificateSigningRequest"
+
+/**
  * @brief The key for the device certificate entry in the response payload of the Provisioning CreateKeysAndCertificate
  * service API.
  */
@@ -618,10 +624,10 @@ AwsIotProvisioningError_t _AwsIotProvisioning_CalculateCertFromCsrPayloadSize( c
  * @return #AWS_IOT_PROVISIONING_SUCCESS if calculation of the payload size is
  * successful; otherwise the appropriate error code.
  */
-AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateCertificateFromCsrRequestPayload( const char * pCertificateSigningRequest,
-                                                                                               size_t csrLength,
-                                                                                               uint8_t * pSerializationBuffer,
-                                                                                               size_t * pBufferSize );
+AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateCertFromCsrRequestPayload( const char * pCertificateSigningRequest,
+                                                                                        size_t csrLength,
+                                                                                        uint8_t * pSerializationBuffer,
+                                                                                        size_t pBufferSize );
 
 /**
  * @brief Serializes payload data for MQTT request to the Provisioning RegisterThing service API.

--- a/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
+++ b/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
@@ -301,31 +301,31 @@
  * @brief The key string for Certificate-Singing Request value in the request payload
  * to the MQTT CreateCertificateFromCsr service API.
  */
-#define PROVISIONING_CREATE_CERT_FROM_CSR_REQUEST_PAYLOAD_PEM_STRING                              "certificateSigningRequest"
+#define PROVISIONING_CREATE_CERT_FROM_CSR_REQUEST_PAYLOAD_PEM_STRING                    "certificateSigningRequest"
 
 /**
- * @brief The key for the device certificate entry in the response payload of the Provisioning CreateKeysAndCertificate
- * service API.
+ * @brief The key for the certificate PEM data in the response payloads of the
+ * MQTT Fleet Provisioning APIs.
  */
-#define PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_PEM_STRING          "certificatePem"
+#define PROVISIONING_SERVER_RESPONSE_PAYLOAD_CERTIFICATE_PEM_STRING                     "certificatePem"
 
 /**
- * @brief The key for the certificate Id entry in the response payload of the Provisioning CreateKeysAndCertificate
- * service API.
+ * @brief The key for the certificate Id data in in the response payloads of the
+ * MQTT Fleet Provisioning APIs.
  */
-#define PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_ID_STRING           "certificateId"
+#define PROVISIONING_SERVER_RESPONSE_PAYLOAD_CERTIFICATE_ID_STRING                      "certificateId"
 
 /**
- * @brief The key for the private key entry in the response payload of the Provisioning CreateKeysAndCertificate service
- * API.
+ * @brief The key for the private key data in the response payload of the
+ * MQTT CreateKeysAndCertificate service API of Fleet Provisioning.
  */
-#define PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_PRIVATE_KEY_STRING              "privateKey"
+#define PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_PRIVATE_KEY_STRING    "privateKey"
 
 /**
- * @brief The key for the token key entry in the response payload of the Provisioning CreateKeysAndCertificate service
- * API.
+ * @brief The key for the token key data in the response payloads of the
+ * MQTT Fleet Provisioning APIs.
  */
-#define PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_CERTIFICATE_TOKEN_KEY_STRING    "certificateOwnershipToken"
+#define PROVISIONING_SERVER_RESPONSE_PAYLOAD_CERTIFICATE_TOKEN_KEY_STRING               "certificateOwnershipToken"
 
 /**
  * @brief The common path in the request and response MQTT topics of the Provisioning RegisterThing service API.

--- a/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
+++ b/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
@@ -263,49 +263,6 @@
  *
  * @note The complete response topics are suffixed with `AWS_IOT_ACCEPTED_SUFFIX` or `AWS_IOT_REJECTED_SUFFIX` strings.
  * It should be utilized in the @ref provisioning_function_registerthing API function.
- * <<<<<<< HEAD
- * =======
- */
-#define PROVISIONING_CREATE_CERT_FROM_CSR_RESPONSE_TOPIC_FILTER \
-    "$aws/certificates/create-from-csr/"PROVISIONING_FORMAT
-
-/**
- * @brief Length of the response topic filter for the MQTT CreateCertificateFromCsr service API.
- */
-#define PROVISIONING_CREATE_CERT_FROM_CSR_RESPONSE_TOPIC_FILTER_LENGTH \
-    ( ( uint16_t ) ( sizeof( PROVISIONING_CREATE_CERT_FROM_CSR_RESPONSE_TOPIC_FILTER ) - 1 ) )
-
-/**
- * @brief The length of the longest response topic of the MQTT CreateCertificateFromCsr service API.
- * Out of the two response topics, the "rejected" has the longest length.
- */
-#define PROVISIONING_CREATE_CERT_FROM_CSR_RESPONSE_MAX_TOPIC_LENGTH \
-    ( PROVISIONING_CREATE_CERT_FROM_CSR_RESPONSE_TOPIC_FILTER_LENGTH + sizeof( AWS_IOT_REJECTED_SUFFIX ) )
-
-/**
- * @brief The request topic for the MQTT CreateCertificateFromCsr service API.
- *
- * @note It should be utilized in the @ref provisioning_function_registerthing API function.
- */
-#define PROVISIONING_CREATE_CERT_FROM_CSR_REQUEST_TOPIC \
-    "$aws/certificates/create-from-csr/"PROVISIONING_FORMAT
-
-/**
- * @brief The length of the request topic for the MQTT CreateCertificateFromCsr service API.
- */
-#define PROVISIONING_CREATE_CERT_FROM_CSR_REQUEST_TOPIC_LENGTH \
-    ( ( uint16_t ) ( sizeof( PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_REQUEST_TOPIC ) - 1 ) )
-
-/**
- * @brief The key string for Certificate-Singing Request value in the request payload
- * to the MQTT CreateCertificateFromCsr service API.
- */
-#define PROVISIONING_CREATE_CERT_FROM_CSR_REQUEST_PAYLOAD_PEM_STRING    "certificateSigningRequest"
-
-/**
- * @brief The key for the device certificate entry in the response payload of the Provisioning CreateKeysAndCertificate
- * service API.
- * >>>>>>> origin/feat/csr-in-fleet-provisioning
  */
 #define PROVISIONING_CREATE_CERT_FROM_CSR_RESPONSE_TOPIC_FILTER \
     "$aws/certificates/create-from-csr/"PROVISIONING_FORMAT
@@ -635,7 +592,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseRegisterThingResponse( AwsIot
  * serialized payload data.
  * @param[out] pBufferSize This will be populated with the size of the allocated payload data buffer.
  *
- * @return #AWS_IOT_PROVISIONING_SUCCESS if serialization is successful; otherwise* #AWS_IOT_PROVISIONING_INTERNAL_FAILURE
+ * @return #AWS_IOT_PROVISIONING_SUCCESS if serialization is successful; otherwise #AWS_IOT_PROVISIONING_INTERNAL_FAILURE
  * for any serialization error.
  */
 AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateKeysAndCertificateRequestPayload( uint8_t ** pSerializationBuffer,

--- a/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
+++ b/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
@@ -508,7 +508,7 @@ typedef struct _provisioningOperation
                                          * API functions
                                          * @ref provisioning_function_createkeysandcertificate,
                                          * @ref provisioning_function_createcertificatefromcsr
-                                         * and @refprovisioning_function_registerthing. */
+                                         * and @ref provisioning_function_registerthing. */
 } _provisioningOperation_t;
 
 /*----------------- Declaration of INTERNAL global variables --------------------*/

--- a/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
+++ b/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
@@ -310,7 +310,7 @@
 #define PROVISIONING_SERVER_RESPONSE_PAYLOAD_CERTIFICATE_PEM_STRING                     "certificatePem"
 
 /**
- * @brief The key for the certificate Id data in in the response payloads of the
+ * @brief The key for the certificate Id data in the response payload of the
  * MQTT Fleet Provisioning APIs.
  */
 #define PROVISIONING_SERVER_RESPONSE_PAYLOAD_CERTIFICATE_ID_STRING                      "certificateId"
@@ -322,7 +322,7 @@
 #define PROVISIONING_CREATE_KEYS_AND_CERTIFICATE_RESPONSE_PAYLOAD_PRIVATE_KEY_STRING    "privateKey"
 
 /**
- * @brief The key for the token key data in the response payloads of the
+ * @brief The key for the token key data in the response payload of the
  * MQTT Fleet Provisioning APIs.
  */
 #define PROVISIONING_SERVER_RESPONSE_PAYLOAD_CERTIFICATE_TOKEN_KEY_STRING               "certificateOwnershipToken"
@@ -539,6 +539,7 @@ size_t _AwsIotProvisioning_GenerateRegisterThingTopicFilter( const char * pTempl
  * @param[in] pResponsePayload The response payload from the server to parse.
  * @param[in] payloadLength The length of the response payload.
  * @param[in] userCallbackInfo The user-provided callback to invoke on successful parsing of response.
+ *
  * @return Returns #AWS_IOT_PROVISIONING_SUCCESS when parsing is successful, otherwise the appropriate error code.
  */
 AwsIotProvisioningError_t _AwsIotProvisioning_ParseKeysAndCertificateResponse( AwsIotStatus_t responseType,
@@ -557,6 +558,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseKeysAndCertificateResponse( A
  * @param[in] pResponsePayload The response payload from the server to parse.
  * @param[in] payloadLength The length of the response payload.
  * @param[in] userCallbackInfo The user-provided callback to invoke on successful parsing of response.
+ *
  * @return Returns #AWS_IOT_PROVISIONING_SUCCESS when parsing is successful, otherwise the appropriate error code.
  */
 AwsIotProvisioningError_t _AwsIotProvisioning_ParseCsrResponse( AwsIotStatus_t responseType,
@@ -572,6 +574,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseCsrResponse( AwsIotStatus_t r
  * @param[in] pResponsePayload The response payload from the server to parse.
  * @param[in] responsePayloadLength The length of the response payload.
  * @param[in] userCallbackInfo The user-provided callback to invoke on successful parsing of response.
+ *
  * @return Returns #AWS_IOT_PROVISIONING_SUCCESS when parsing is successful, otherwise the appropriate error code.
  */
 AwsIotProvisioningError_t _AwsIotProvisioning_ParseRegisterThingResponse( AwsIotStatus_t responseType,
@@ -585,6 +588,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseRegisterThingResponse( AwsIot
  * @param[out] pSerializationBuffer This will be assigned to a buffer that will be allocated and populated with the
  * serialized payload data.
  * @param[out] pBufferSize This will be populated with the size of the allocated payload data buffer.
+ *
  * @return #AWS_IOT_PROVISIONING_SUCCESS if serialization is successful; otherwise* #AWS_IOT_PROVISIONING_INTERNAL_FAILURE
  * for any serialization error.
  */
@@ -603,6 +607,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_SerializeCreateKeysAndCertificateR
  * which represents the data to be serialized in the payload.
  * @param[in] csrLength The length of the Certificate-Signing Request string.
  * @param[in] pPayloadSize This will be populated with the size of the serialized data.
+ *
  * @return `true` if calculation of the payload size is successful; otherwise `false`.
  */
 bool _AwsIotProvisioning_CalculateCertFromCsrPayloadSize( const char * pCertificateSigningRequest,
@@ -616,7 +621,8 @@ bool _AwsIotProvisioning_CalculateCertFromCsrPayloadSize( const char * pCertific
  * @param[in] pCertificateSigningRequest The Certificate-Signing Request string to serialize for the request.
  * @param[in] csrLength The length of the Certificate-Signing Request string.
  * @param[in, out] pSerializationBuffer The buffer for storing the serialized payload data.
- * @param[in] pBufferSize THe size of the serialization buffer.
+ * @param[in] pBufferSize The size of the serialization buffer.
+ *
  * @return `true` if serialization is successful; otherwise `false` for any serialization error.
  */
 bool _AwsIotProvisioning_SerializeCreateCertFromCsrRequestPayload( const char * pCertificateSigningRequest,
@@ -633,6 +639,7 @@ bool _AwsIotProvisioning_SerializeCreateCertFromCsrRequestPayload( const char * 
  *
  * @note The calling code is responsible for de-allocation of the buffer memory.
  * @param[out] pBufferSize This will be populated with the size of the allocated payload data buffer.
+ *
  * @return #AWS_IOT_PROVISIONING_SUCCESS if serialization is successful; otherwise #AWS_IOT_PROVISIONING_INTERNAL_FAILURE
  * for any serialization error.
  */

--- a/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
+++ b/libraries/aws/provisioning/src/private/aws_iot_provisioning_internal.h
@@ -467,7 +467,7 @@ typedef union _provisioningCallbackInfo
     AwsIotProvisioningCreateKeysAndCertificateCallbackInfo_t createKeysAndCertificateCallback;
 
     /** @brief The user-callback passed to @ref provisioning_function_createcertificatefromcsr. */
-    AwsIotProvisioningCreateCertFromCsrCallbackInfo_t createCertificateFromCsrCallback;
+    AwsIotProvisioningCreateCertFromCsrCallbackInfo_t createCertFromCsrCallback;
 
     /** @brief The user-callback passed to @ref provisioning_function_registerthing. */
     AwsIotProvisioningRegisterThingCallbackInfo_t registerThingCallback;
@@ -483,7 +483,7 @@ typedef union _provisioningCallbackInfo
  * @param[in] usercallback The user-provided callback to invoke on successful parsing of device credentials.
  */
 typedef AwsIotProvisioningError_t ( * _provisioningServerResponseParser)( AwsIotStatus_t responseType,
-                                                                          const void * responsePayload,
+                                                                          const uint8_t * responsePayload,
                                                                           size_t responsePayloadLength,
                                                                           const _provisioningCallbackInfo_t * userCallback );
 
@@ -542,7 +542,7 @@ size_t _AwsIotProvisioning_GenerateRegisterThingTopicFilter( const char * pTempl
  * @return Returns #AWS_IOT_PROVISIONING_SUCCESS when parsing is successful, otherwise the appropriate error code.
  */
 AwsIotProvisioningError_t _AwsIotProvisioning_ParseKeysAndCertificateResponse( AwsIotStatus_t responseType,
-                                                                               const void * pResponsePayload,
+                                                                               const uint8_t * pResponsePayload,
                                                                                size_t payloadLength,
                                                                                const _provisioningCallbackInfo_t * userCallbackInfo );
 
@@ -560,7 +560,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseKeysAndCertificateResponse( A
  * @return Returns #AWS_IOT_PROVISIONING_SUCCESS when parsing is successful, otherwise the appropriate error code.
  */
 AwsIotProvisioningError_t _AwsIotProvisioning_ParseCsrResponse( AwsIotStatus_t responseType,
-                                                                const void * pResponsePayload,
+                                                                const uint8_t * pResponsePayload,
                                                                 size_t payloadLength,
                                                                 const _provisioningCallbackInfo_t * userCallbackInfo );
 
@@ -575,7 +575,7 @@ AwsIotProvisioningError_t _AwsIotProvisioning_ParseCsrResponse( AwsIotStatus_t r
  * @return Returns #AWS_IOT_PROVISIONING_SUCCESS when parsing is successful, otherwise the appropriate error code.
  */
 AwsIotProvisioningError_t _AwsIotProvisioning_ParseRegisterThingResponse( AwsIotStatus_t responseType,
-                                                                          const void * pResponsePayload,
+                                                                          const uint8_t * pResponsePayload,
                                                                           size_t responsePayloadLength,
                                                                           const _provisioningCallbackInfo_t * userCallbackInfo );
 

--- a/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_api.c
+++ b/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_api.c
@@ -844,7 +844,7 @@ TEST( Provisioning_Unit_API, CreateKeysAndCertificateAPICorruptDataInResponse )
     /*************** Response payload without certificate entry********************/
     const uint8_t serverResponseWithoutCertificate[] =
     {
-        0xA2,                                                       /* # map( 2 ) */
+        0xA1,                                                       /* # map( 1 ) */
         0x6A,                                                       /* # text( 10 ) */
         /* THERE IS NO ENTRY FOR "CertificatePem"!! */
         0x70, 0x72, 0x69, 0x76, 0x61, 0x74, 0x65, 0x4B, 0x65, 0x79, /* # "privateKey" */

--- a/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_parser.c
+++ b/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_parser.c
@@ -170,6 +170,48 @@ AwsIotProvisioningCreateKeysAndCertificateResponse_t _expectedKeysAndCertificate
     .u.acceptedResponse.ownershipTokenLength       = 6,
 };
 
+/**
+ * @brief Sample CBOR encoded accepted response payload CreateCertificateFromCsr
+ * service API.
+ */
+const uint8_t _sampleAcceptedCertFromCsrResponse[] =
+{
+    0xA3,                                                                               /* # map( 3 ) */
+    0x6E,                                                                               /* # text( 14 ) */
+    0x63, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x65, 0x50, 0x65, 0x6D, /* # "certificatePem" */
+    0x67,                                                                               /* # text(7) */
+    0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67,                                           /* # "abcdefg" */
+    0x6D,                                                                               /* # text(13) */
+    0x63, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x65, 0x49, 0x64,       /* # "certificateId" */
+    0x66,                                                                               /* # text(6) */
+    0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D,                                                 /* # "hijklm" */
+    0x78, 0x19,                                                                         /*# text(25) */
+    0x63, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x65, 0x4F, 0x77, 0x6E,
+    0x65, 0x72, 0x73, 0x68, 0x69, 0x70, 0x54, 0x6F, 0x6B, 0x65, 0x6E,                   /*# "certificateOwnershipToken"
+                                                                                         * */
+    0x66,                                                                               /*# text(6) */
+    0x54, 0x6F, 0x6B, 0x65, 0x6E, 0x21                                                  /*# "Token!" */
+};
+
+/**
+ * @brief Represents the expected parsed CSR response information that the parser under
+ * parser under test should pass to the user-callback.
+ * This object will be provided as a context parameter for the callback object supplied
+ * to the parser in the test, to verify the parse information by the parser.
+ */
+AwsIotProvisioningCreateCertFromCsrResponse_t _expectedCertFromCsrParsedParams =
+{
+    .statusCode                              = AWS_IOT_PROVISIONING_SERVER_STATUS_ACCEPTED,
+    .u.acceptedResponse.pDeviceCertificate   = ( const char * )
+                                               &_sampleAcceptedCertFromCsrResponse[ 17 ],
+    .u.acceptedResponse.deviceCertLength     = 7,
+    .u.acceptedResponse.pCertId              = ( const char * )
+                                               &_sampleAcceptedCertFromCsrResponse[ 39 ],
+    .u.acceptedResponse.certIdLength         = 6,
+    .u.acceptedResponse.pCertOwnershipToken  = ( const char * )
+                                               &_sampleAcceptedCertFromCsrResponse[ 73 ],
+    .u.acceptedResponse.ownershipTokenLength = 6,
+};
 /*-----------------------------------------------------------*/
 
 /**
@@ -183,11 +225,25 @@ static void _verifyParsedRejectedResponse( const AwsIotProvisioningRejectedRespo
  * @brief Test user-callback to set expectations on parsing of #_sampleRejectedServerResponsePayload as rejected server
  * response. It will be passed as context parameter in callback parameter passed in tests.
  */
+static void _testCreateCertFromCsrRejectedCallback( void * contextParam,
+                                                    const AwsIotProvisioningCreateCertFromCsrResponse_t * pResponseInfo );
+
+/**
+ * @brief Test user-callback to set expectations on parsing of #_sampleRejectedServerResponsePayload as rejected server
+ * response. It will be passed as context parameter in callback parameter passed in tests.
+ */
 static void _testCreateKeysAndCertificateRejectedCallback( void * contextParam,
                                                            const AwsIotProvisioningCreateKeysAndCertificateResponse_t * pResponseInfo );
 
 /**
- * @brief Test user-callback to set expectations on parsing of #_sampleAcceptedKeysAndCertificateResponse as rejected
+ * @brief Test user-callback to set expectations on parsing of #_sampleAcceptedCertFromCsrResponse as accepted
+ * server response. It will be passed as context parameter in callback parameter passed in tests.
+ */
+static void _testCreateCertFromCsrAcceptedCallback( void * contextParam,
+                                                    const AwsIotProvisioningCreateCertFromCsrResponse_t * pResponseInfo );
+
+/**
+ * @brief Test user-callback to set expectations on parsing of #_sampleAcceptedKeysAndCertificateResponse as accepted
  * server response. It will be passed as context parameter in callback parameter passed in tests.
  */
 static void _testCreateKeysAndCertificateAcceptedCallback( void * contextParam,
@@ -285,8 +341,64 @@ static void _testCreateKeysAndCertificateAcceptedCallback( void * contextParam,
 
 /*-----------------------------------------------------------*/
 
+static void _testCreateCertFromCsrRejectedCallback( void * contextParam,
+                                                    const AwsIotProvisioningCreateCertFromCsrResponse_t * pResponseInfo )
+{
+    AwsIotProvisioningRejectedResponse_t * pExpectedParams =
+        ( AwsIotProvisioningRejectedResponse_t * ) contextParam;
+
+    AwsIotProvisioning_Assert( pResponseInfo->statusCode == _expectedStatusCode );
+    /* Verify that the rejected response was parsed as expected. */
+    _verifyParsedRejectedResponse( pExpectedParams, &pResponseInfo->u.rejectedResponse );
+}
+
+/*-----------------------------------------------------------*/
+
+static void _testCreateCertFromCsrAcceptedCallback( void * contextParam,
+                                                    const AwsIotProvisioningCreateCertFromCsrResponse_t * pResponseInfo )
+{
+    AwsIotProvisioningCreateCertFromCsrResponse_t * pExpectedParams =
+        ( AwsIotProvisioningCreateCertFromCsrResponse_t * ) contextParam;
+
+    /* Disable unused variable warnings. */
+    ( void ) pExpectedParams;
+    ( void ) pResponseInfo;
+
+    /* Verify that the rejected response was parsed as expected. */
+    AwsIotProvisioning_Assert( pResponseInfo->statusCode == AWS_IOT_PROVISIONING_SERVER_STATUS_ACCEPTED );
+
+    AwsIotProvisioning_Assert(
+        pExpectedParams->u.acceptedResponse.deviceCertLength ==
+        pResponseInfo->u.acceptedResponse.deviceCertLength );
+    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.pDeviceCertificate ==
+                               pResponseInfo->u.acceptedResponse.pDeviceCertificate );
+    AwsIotProvisioning_Assert(
+        pExpectedParams->u.acceptedResponse.certIdLength ==
+        pResponseInfo->u.acceptedResponse.certIdLength );
+    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.pCertId ==
+                               pResponseInfo->u.acceptedResponse.pCertId );
+    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.ownershipTokenLength ==
+                               pResponseInfo->u.acceptedResponse.ownershipTokenLength );
+    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.pCertOwnershipToken ==
+                               pResponseInfo->u.acceptedResponse.pCertOwnershipToken );
+}
+
+/*-----------------------------------------------------------*/
+
 static void _keysAndCertificateCallbackThatFailsOnInvokation( void * contextParam,
                                                               const AwsIotProvisioningCreateKeysAndCertificateResponse_t * pResponseInfo )
+{
+    ( void ) contextParam;
+    ( void ) pResponseInfo;
+
+    /* As the callback SHOULD NOT be invoked, we will inject an assert failure.*/
+    AwsIotProvisioning_Assert( false );
+}
+
+/*-----------------------------------------------------------*/
+
+static void _certFromCsrCallbackThatFailsOnInvokation( void * contextParam,
+                                                       const AwsIotProvisioningCreateCertFromCsrResponse_t * pResponseInfo )
 {
     ( void ) contextParam;
     ( void ) pResponseInfo;
@@ -367,6 +479,9 @@ TEST_GROUP_RUNNER( Provisioning_Unit_Parser )
     RUN_TEST_CASE( Provisioning_Unit_Parser, TestParseKeysAndCertificateRejectedResponse );
     RUN_TEST_CASE( Provisioning_Unit_Parser, TestParseKeysAndCertificateAcceptedResponse );
     RUN_TEST_CASE( Provisioning_Unit_Parser, TestParseKeysAndCertificateResponseWithMissingEntries );
+    RUN_TEST_CASE( Provisioning_Unit_Parser, TestParseCreateCertFromCsrRejectedResponse );
+    RUN_TEST_CASE( Provisioning_Unit_Parser, TestParseCreateCertFromCsrAcceptedResponse );
+    RUN_TEST_CASE( Provisioning_Unit_Parser, TestParseCreateCertFromCsrResponseWithMissingEntries );
     RUN_TEST_CASE( Provisioning_Unit_Parser, TestRegisterThingParsesWithRejectedResponseContainingMissingEntries );
     RUN_TEST_CASE( Provisioning_Unit_Parser, TestDeviceCredentialsParsesWithRejectedResponseContainingMissingEntries );
 }
@@ -484,6 +599,102 @@ TEST( Provisioning_Unit_Parser, TestParseKeysAndCertificateResponseWithMissingEn
                                                                                                                &wrapperCallback ) );
 }
 
+/**
+ * @brief Verifies that the parser function for the CSR response payload can parse
+ * a rejected response from the MQTT CreateCertificateFromCsr service API.
+ */
+TEST( Provisioning_Unit_Parser, TestParseCreateCertFromCsrRejectedResponse )
+{
+    _provisioningCallbackInfo_t wrapperCallback;
+
+    wrapperCallback.createCertFromCsrCallback.userParam = &_expectedParsedParams;
+    wrapperCallback.createCertFromCsrCallback.function = _testCreateCertFromCsrRejectedCallback;
+
+    TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_SERVER_REFUSED, _AwsIotProvisioning_ParseCsrResponse( AWS_IOT_REJECTED,
+                                                                                                  _sampleRejectedServerResponsePayload,
+                                                                                                  sizeof( _sampleRejectedServerResponsePayload ),
+                                                                                                  &wrapperCallback ) );
+}
+
+/**
+ * @brief Verifies that the CSR response parser function can parse the
+ * accepted response payload from the MQTT CreateCertificateFromCsr service API.
+ */
+TEST( Provisioning_Unit_Parser, TestParseCreateCertFromCsrAcceptedResponse )
+{
+    _provisioningCallbackInfo_t wrapperCallback;
+
+    wrapperCallback.createCertFromCsrCallback.userParam = &_expectedCertFromCsrParsedParams;
+    wrapperCallback.createCertFromCsrCallback.function = _testCreateCertFromCsrAcceptedCallback;
+
+    TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_SUCCESS, _AwsIotProvisioning_ParseCsrResponse( AWS_IOT_ACCEPTED,
+                                                                                           _sampleAcceptedCertFromCsrResponse,
+                                                                                           sizeof( _sampleAcceptedCertFromCsrResponse ),
+                                                                                           &wrapperCallback ) );
+}
+
+/**
+ * @brief Verifies that the CSR response parser  does not call the user-callback
+ * when the server response payload has missing entries of the expected data in
+ * the response.
+ */
+TEST( Provisioning_Unit_Parser, TestParseCreateCertFromCsrResponseWithMissingEntries )
+{
+    _provisioningCallbackInfo_t wrapperCallback;
+
+    wrapperCallback.createCertFromCsrCallback.userParam = NULL;
+    wrapperCallback.createCertFromCsrCallback.function = _certFromCsrCallbackThatFailsOnInvokation;
+
+    /*************** Response payload only with certificate Pem entry********************/
+    const uint8_t payloadWithOnlyCertificatePem[] =
+    {
+        0xA1,                                                                               /* # map( 1 ) */
+        0x6E,                                                                               /* # text( 14 ) */
+        0x63, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x65, 0x50, 0x65, 0x6D, /* # "certificatePem" */
+        0x67,                                                                               /* # text(7) */
+        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67,                                           /* # "abcdefg" */
+    };
+
+
+    TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_BAD_RESPONSE, _AwsIotProvisioning_ParseCsrResponse( AWS_IOT_ACCEPTED,
+                                                                                                payloadWithOnlyCertificatePem,
+                                                                                                sizeof( payloadWithOnlyCertificatePem ),
+                                                                                                &wrapperCallback ) );
+
+    /*************** Response payload only with certificate ID entry********************/
+    const uint8_t payloadWithOnlyCertificateId[] =
+    {
+        0xA1,                                                                         /* # map( 1 ) */
+        0x6D,                                                                         /* # text(13) */
+        0x63, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x65, 0x49, 0x64, /* # "certificateId" */
+        0x66,                                                                         /* # text(6) */
+        0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D,                                           /* # "hijklm" */
+    };
+
+
+    TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_BAD_RESPONSE, _AwsIotProvisioning_ParseCsrResponse( AWS_IOT_ACCEPTED,
+                                                                                                payloadWithOnlyCertificateId,
+                                                                                                sizeof( payloadWithOnlyCertificateId ),
+                                                                                                &wrapperCallback ) );
+
+    /*************** Response payload only with ownership token entry********************/
+    const uint8_t payloadWithOnlyToken[] =
+    {
+        0xA1,                                                             /* # map( 1 ) */
+        0x78, 0x19,                                                       /*# text(25) */
+        0x63, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x65, 0x4F, 0x77, 0x6E,
+        0x65, 0x72, 0x73, 0x68, 0x69, 0x70, 0x54, 0x6F, 0x6B, 0x65, 0x6E, /*# "certificateOwnershipToken"
+                                                                           * */
+        0x66,                                                             /*# text(6) */
+        0x54, 0x6F, 0x6B, 0x65, 0x6E, 0x21                                /*# "Token!" */
+    };
+
+
+    TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_BAD_RESPONSE, _AwsIotProvisioning_ParseCsrResponse( AWS_IOT_ACCEPTED,
+                                                                                                payloadWithOnlyToken,
+                                                                                                sizeof( payloadWithOnlyToken ),
+                                                                                                &wrapperCallback ) );
+}
 
 /**
  * @brief Verifies the parser function behavior (_AwsIotProvisioning_ParseRegisterThingResponse) when the

--- a/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_parser.c
+++ b/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_parser.c
@@ -282,11 +282,11 @@ static void _verifyParsedRejectedResponse( const AwsIotProvisioningRejectedRespo
 
     /* Verify that the rejected response was parsed as expected. */
     TEST_ASSERT( pParsedData->errorCodeLength == pExpectedData->errorCodeLength );
-    TEST_ASSERT( 0 == memcmp( pParsedData->pErrorCode,
+    TEST_ASSERT_EQUAL_MEMORY( pParsedData->pErrorCode,
                               pExpectedData->pErrorCode,
                               pExpectedData->errorCodeLength ) );
     TEST_ASSERT( pParsedData->errorMessageLength == pExpectedData->errorMessageLength );
-    TEST_ASSERT( 0 == memcmp( pParsedData->pErrorMessage,
+    TEST_ASSERT_EQUAL_MEMORY( pParsedData->pErrorMessage,
                               pExpectedData->pErrorMessage,
                               pExpectedData->errorMessageLength ) );
 }
@@ -392,7 +392,7 @@ static void _keysAndCertificateCallbackThatFailsOnInvokation( void * contextPara
     ( void ) pResponseInfo;
 
     /* As the callback SHOULD NOT be invoked, we will inject an assert failure.*/
-    TEST_ASSERT( false );
+    TEST_FAIL_MESSAGE( "This callback SHOULD NOT be invoked in the test" );
 }
 
 /*-----------------------------------------------------------*/
@@ -404,7 +404,7 @@ static void _certFromCsrCallbackThatFailsOnInvokation( void * contextParam,
     ( void ) pResponseInfo;
 
     /* As the callback SHOULD NOT be invoked, we will inject an assert failure.*/
-    TEST_ASSERT( false );
+    TEST_FAIL_MESSAGE( "This callback SHOULD NOT be invoked in the test" );
 }
 
 /*-----------------------------------------------------------*/
@@ -416,7 +416,7 @@ static void _registerThingCallbackThatFailsOnInvokation( void * contextParam,
     ( void ) pResponseInfo;
 
     /* As the callback SHOULD NOT be invoked, we will inject an assert failure.*/
-    TEST_ASSERT( false );
+    TEST_FAIL_MESSAGE( "This callback SHOULD NOT be invoked in the test" );
 }
 
 

--- a/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_parser.c
+++ b/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_parser.c
@@ -421,7 +421,7 @@ TEST( Provisioning_Unit_Parser, TestParseKeysAndCertificateResponseWithMissingEn
     /*************** Response payload only with private key ********************/
     const uint8_t payloadWithOnlyPrivateKey[] =
     {
-        0xA2,                                                       /* # map( 1 ) */
+        0xA1,                                                       /* # map( 1 ) */
         0x6A,                                                       /* # text( 10 ) */
         0x70, 0x72, 0x69, 0x76, 0x61, 0x74, 0x65, 0x4B, 0x65, 0x79, /* # "privateKey" */
         0x4A,                                                       /* # bytes( 10 ) */

--- a/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_parser.c
+++ b/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_parser.c
@@ -202,7 +202,7 @@ const uint8_t _sampleAcceptedCertFromCsrResponse[] =
 AwsIotProvisioningCreateCertFromCsrResponse_t _expectedCertFromCsrParsedParams =
 {
     .statusCode                              = AWS_IOT_PROVISIONING_SERVER_STATUS_ACCEPTED,
-    .u.acceptedResponse.pDeviceCertificate   = ( const char * )
+    .u.acceptedResponse.pDeviceCert          = ( const char * )
                                                &_sampleAcceptedCertFromCsrResponse[ 17 ],
     .u.acceptedResponse.deviceCertLength     = 7,
     .u.acceptedResponse.pCertId              = ( const char * )
@@ -370,8 +370,8 @@ static void _testCreateCertFromCsrAcceptedCallback( void * contextParam,
     AwsIotProvisioning_Assert(
         pExpectedParams->u.acceptedResponse.deviceCertLength ==
         pResponseInfo->u.acceptedResponse.deviceCertLength );
-    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.pDeviceCertificate ==
-                               pResponseInfo->u.acceptedResponse.pDeviceCertificate );
+    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.pDeviceCert ==
+                               pResponseInfo->u.acceptedResponse.pDeviceCert );
     AwsIotProvisioning_Assert(
         pExpectedParams->u.acceptedResponse.certIdLength ==
         pResponseInfo->u.acceptedResponse.certIdLength );

--- a/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_parser.c
+++ b/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_parser.c
@@ -281,14 +281,14 @@ static void _verifyParsedRejectedResponse( const AwsIotProvisioningRejectedRespo
     ( void ) pParsedData;
 
     /* Verify that the rejected response was parsed as expected. */
-    AwsIotProvisioning_Assert( pParsedData->errorCodeLength == pExpectedData->errorCodeLength );
-    AwsIotProvisioning_Assert( 0 == memcmp( pParsedData->pErrorCode,
-                                            pExpectedData->pErrorCode,
-                                            pExpectedData->errorCodeLength ) );
-    AwsIotProvisioning_Assert( pParsedData->errorMessageLength == pExpectedData->errorMessageLength );
-    AwsIotProvisioning_Assert( 0 == memcmp( pParsedData->pErrorMessage,
-                                            pExpectedData->pErrorMessage,
-                                            pExpectedData->errorMessageLength ) );
+    TEST_ASSERT( pParsedData->errorCodeLength == pExpectedData->errorCodeLength );
+    TEST_ASSERT( 0 == memcmp( pParsedData->pErrorCode,
+                              pExpectedData->pErrorCode,
+                              pExpectedData->errorCodeLength ) );
+    TEST_ASSERT( pParsedData->errorMessageLength == pExpectedData->errorMessageLength );
+    TEST_ASSERT( 0 == memcmp( pParsedData->pErrorMessage,
+                              pExpectedData->pErrorMessage,
+                              pExpectedData->errorMessageLength ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -299,7 +299,7 @@ static void _testCreateKeysAndCertificateRejectedCallback( void * contextParam,
     AwsIotProvisioningRejectedResponse_t * pExpectedParams =
         ( AwsIotProvisioningRejectedResponse_t * ) contextParam;
 
-    AwsIotProvisioning_Assert( pResponseInfo->statusCode == _expectedStatusCode );
+    TEST_ASSERT( pResponseInfo->statusCode == _expectedStatusCode );
     /* Verify that the rejected response was parsed as expected. */
     _verifyParsedRejectedResponse( pExpectedParams, &pResponseInfo->u.rejectedResponse );
 }
@@ -317,26 +317,26 @@ static void _testCreateKeysAndCertificateAcceptedCallback( void * contextParam,
     ( void ) pResponseInfo;
 
     /* Verify that the rejected response was parsed as expected. */
-    AwsIotProvisioning_Assert( pResponseInfo->statusCode == AWS_IOT_PROVISIONING_SERVER_STATUS_ACCEPTED );
+    TEST_ASSERT( pResponseInfo->statusCode == AWS_IOT_PROVISIONING_SERVER_STATUS_ACCEPTED );
 
-    AwsIotProvisioning_Assert(
+    TEST_ASSERT(
         pExpectedParams->u.acceptedResponse.deviceCertificateLength ==
         pResponseInfo->u.acceptedResponse.deviceCertificateLength );
-    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.pDeviceCertificate ==
-                               pResponseInfo->u.acceptedResponse.pDeviceCertificate );
-    AwsIotProvisioning_Assert(
+    TEST_ASSERT( pExpectedParams->u.acceptedResponse.pDeviceCertificate ==
+                 pResponseInfo->u.acceptedResponse.pDeviceCertificate );
+    TEST_ASSERT(
         pExpectedParams->u.acceptedResponse.certificateIdLength ==
         pResponseInfo->u.acceptedResponse.certificateIdLength );
-    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.pCertificateId ==
-                               pResponseInfo->u.acceptedResponse.pCertificateId );
-    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.privateKeyLength ==
-                               pResponseInfo->u.acceptedResponse.privateKeyLength );
-    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.pPrivateKey ==
-                               pResponseInfo->u.acceptedResponse.pPrivateKey );
-    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.ownershipTokenLength ==
-                               pResponseInfo->u.acceptedResponse.ownershipTokenLength );
-    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.pCertificateOwnershipToken ==
-                               pResponseInfo->u.acceptedResponse.pCertificateOwnershipToken );
+    TEST_ASSERT( pExpectedParams->u.acceptedResponse.pCertificateId ==
+                 pResponseInfo->u.acceptedResponse.pCertificateId );
+    TEST_ASSERT( pExpectedParams->u.acceptedResponse.privateKeyLength ==
+                 pResponseInfo->u.acceptedResponse.privateKeyLength );
+    TEST_ASSERT( pExpectedParams->u.acceptedResponse.pPrivateKey ==
+                 pResponseInfo->u.acceptedResponse.pPrivateKey );
+    TEST_ASSERT( pExpectedParams->u.acceptedResponse.ownershipTokenLength ==
+                 pResponseInfo->u.acceptedResponse.ownershipTokenLength );
+    TEST_ASSERT( pExpectedParams->u.acceptedResponse.pCertificateOwnershipToken ==
+                 pResponseInfo->u.acceptedResponse.pCertificateOwnershipToken );
 }
 
 /*-----------------------------------------------------------*/
@@ -347,7 +347,7 @@ static void _testCreateCertFromCsrRejectedCallback( void * contextParam,
     AwsIotProvisioningRejectedResponse_t * pExpectedParams =
         ( AwsIotProvisioningRejectedResponse_t * ) contextParam;
 
-    AwsIotProvisioning_Assert( pResponseInfo->statusCode == _expectedStatusCode );
+    TEST_ASSERT( pResponseInfo->statusCode == _expectedStatusCode );
     /* Verify that the rejected response was parsed as expected. */
     _verifyParsedRejectedResponse( pExpectedParams, &pResponseInfo->u.rejectedResponse );
 }
@@ -365,22 +365,22 @@ static void _testCreateCertFromCsrAcceptedCallback( void * contextParam,
     ( void ) pResponseInfo;
 
     /* Verify that the rejected response was parsed as expected. */
-    AwsIotProvisioning_Assert( pResponseInfo->statusCode == AWS_IOT_PROVISIONING_SERVER_STATUS_ACCEPTED );
+    TEST_ASSERT( pResponseInfo->statusCode == AWS_IOT_PROVISIONING_SERVER_STATUS_ACCEPTED );
 
-    AwsIotProvisioning_Assert(
+    TEST_ASSERT(
         pExpectedParams->u.acceptedResponse.deviceCertLength ==
         pResponseInfo->u.acceptedResponse.deviceCertLength );
-    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.pDeviceCert ==
-                               pResponseInfo->u.acceptedResponse.pDeviceCert );
-    AwsIotProvisioning_Assert(
+    TEST_ASSERT( pExpectedParams->u.acceptedResponse.pDeviceCert ==
+                 pResponseInfo->u.acceptedResponse.pDeviceCert );
+    TEST_ASSERT(
         pExpectedParams->u.acceptedResponse.certIdLength ==
         pResponseInfo->u.acceptedResponse.certIdLength );
-    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.pCertId ==
-                               pResponseInfo->u.acceptedResponse.pCertId );
-    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.ownershipTokenLength ==
-                               pResponseInfo->u.acceptedResponse.ownershipTokenLength );
-    AwsIotProvisioning_Assert( pExpectedParams->u.acceptedResponse.pCertOwnershipToken ==
-                               pResponseInfo->u.acceptedResponse.pCertOwnershipToken );
+    TEST_ASSERT( pExpectedParams->u.acceptedResponse.pCertId ==
+                 pResponseInfo->u.acceptedResponse.pCertId );
+    TEST_ASSERT( pExpectedParams->u.acceptedResponse.ownershipTokenLength ==
+                 pResponseInfo->u.acceptedResponse.ownershipTokenLength );
+    TEST_ASSERT( pExpectedParams->u.acceptedResponse.pCertOwnershipToken ==
+                 pResponseInfo->u.acceptedResponse.pCertOwnershipToken );
 }
 
 /*-----------------------------------------------------------*/
@@ -392,7 +392,7 @@ static void _keysAndCertificateCallbackThatFailsOnInvokation( void * contextPara
     ( void ) pResponseInfo;
 
     /* As the callback SHOULD NOT be invoked, we will inject an assert failure.*/
-    AwsIotProvisioning_Assert( false );
+    TEST_ASSERT( false );
 }
 
 /*-----------------------------------------------------------*/
@@ -404,7 +404,7 @@ static void _certFromCsrCallbackThatFailsOnInvokation( void * contextParam,
     ( void ) pResponseInfo;
 
     /* As the callback SHOULD NOT be invoked, we will inject an assert failure.*/
-    AwsIotProvisioning_Assert( false );
+    TEST_ASSERT( false );
 }
 
 /*-----------------------------------------------------------*/
@@ -416,7 +416,7 @@ static void _registerThingCallbackThatFailsOnInvokation( void * contextParam,
     ( void ) pResponseInfo;
 
     /* As the callback SHOULD NOT be invoked, we will inject an assert failure.*/
-    AwsIotProvisioning_Assert( false );
+    TEST_ASSERT( false );
 }
 
 
@@ -427,7 +427,7 @@ static void _testRegisterThingRejectedDeviceCallback( void * contextParam,
 {
     AwsIotProvisioningRejectedResponse_t * pExpectedParams = ( AwsIotProvisioningRejectedResponse_t * ) contextParam;
 
-    AwsIotProvisioning_Assert( pResponseInfo->statusCode == _expectedStatusCode );
+    TEST_ASSERT( pResponseInfo->statusCode == _expectedStatusCode );
 
     /* Verify that the rejected response was parsed as expected. */
     _verifyParsedRejectedResponse( pExpectedParams, &pResponseInfo->u.rejectedResponse );

--- a/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_serializer.c
+++ b/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_serializer.c
@@ -42,6 +42,37 @@
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Test string to use as the Certificate-Signing Request data in CSR
+ * payload serializer tests.
+ */
+static const char * _testCsrString = "TestCSR";
+
+/**
+ * @brief The sanity value to use for checking against buffer overrun
+ * behavior in buffers that will be modified by serializer funtions in tests.
+ */
+static const uint8_t _bufferOverrunCheckValue = 0xA5;
+
+/**
+ * @brief The reserve space to keep in test serialization buffers to
+ * check against buffer overrun faults by the serializer functions.
+ */
+static const size_t _reserveSize = 5;
+
+/**
+ * @brief Expected serialization of the above CSR string as the request payload.
+ */
+static const uint8_t _expectedSerialization[] =
+{
+    0xA1,                                                                   /* map(1) */
+    0x78, 0x19,                                                             /* text(25) */
+    0x63, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x65, 0x53, 0x69,
+    0x67, 0x6E, 0x69, 0x6E, 0x67, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, /* "certificateSigningRequest" */
+    0x67,                                                                   /* text(7) */
+    0x54, 0x65, 0x73, 0x74, 0x43, 0x53, 0x52                                /* "TestCSR" */
+};
+
+/**
  * @brief Certificate ID for Provisioning's RegisterThing Request serialization tests.
  */
 static const char * _testCertificateId = "TestCertificateId";
@@ -61,6 +92,57 @@ static const AwsIotProvisioningRequestParameterEntry_t _sampleParameters[] =
     { "Param3", ( sizeof( "Param3" ) - 1 ), "Value3", ( sizeof( "Value3" ) - 1 ) },
 };
 static const size_t _numOfSampleParameters = 3;
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Allocates memory for buffer used in tests for serialization
+ * with reserve space to check against buffer overrun errors by serializer
+ * functions under test.
+ * @note The reserve space is used at the beginning and the end of the
+ * allocated buffer space.
+ */
+uint8_t * _allocateBufferMemoryWithBufferOverrunReserve( size_t sizeOfSerialization,
+                                                         size_t * serializationStartingIndex )
+{
+    /* We will allocate more space than the expected serialization size to perform
+     * buffer overrun checks after the serialization operation.  */
+    size_t totalBufferSize = sizeOfSerialization +
+                             _reserveSize + _reserveSize;
+    uint8_t * testBuffer = unity_malloc_mt( totalBufferSize );
+
+    assert( testBuffer != NULL );
+
+    /* Fill the buffer with the buffer overrun test value which will be */
+    /* checked after the serialization call. */
+    memset( testBuffer, _bufferOverrunCheckValue, totalBufferSize );
+
+    *serializationStartingIndex = _reserveSize;
+
+    return testBuffer;
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Verifies that the reserve space in test buffer used for serialization
+ * is not corrupted by buffer overrun errors in the serializer function under
+ * test.
+ */
+void _checkForBufferOverrun( const uint8_t * buffer,
+                             size_t sizeOfSerialization )
+{
+    size_t totalBufferSize = sizeOfSerialization +
+                             _reserveSize + _reserveSize;
+
+    /* Check that both the front and rear reserve spaces in the buffer are not */
+    /* overwritten. */
+    for( int index = 0; index < _reserveSize; index++ )
+    {
+        assert( _bufferOverrunCheckValue == buffer[ index ] );
+        assert( _bufferOverrunCheckValue == buffer[ totalBufferSize - 1 - index ] );
+    }
+}
 
 /*-----------------------------------------------------------*/
 
@@ -103,6 +185,9 @@ TEST_TEAR_DOWN( Provisioning_Unit_Serializer )
 TEST_GROUP_RUNNER( Provisioning_Unit_Serializer )
 {
     RUN_TEST_CASE( Provisioning_Unit_Serializer, TestSerializeCreateKeysAndCertificatePayloadNominalCase );
+    RUN_TEST_CASE( Provisioning_Unit_Serializer, TestCalculateCertFromCsrPayloadSize );
+    RUN_TEST_CASE( Provisioning_Unit_Serializer, TestSerializeCreateCertFromCsrPayloadWithBuffer );
+    RUN_TEST_CASE( Provisioning_Unit_Serializer, TestSerializeCreateCertFromCsrPayloadFailureCase );
     RUN_TEST_CASE( Provisioning_Unit_Serializer, TestSerializeRegisterThingPayloadNominalCase );
     RUN_TEST_CASE( Provisioning_Unit_Serializer, TestSerializeRegisterThingPayloadCaseWithoutParameters );
 }
@@ -111,8 +196,7 @@ TEST_GROUP_RUNNER( Provisioning_Unit_Serializer )
 
 /**
  * @brief Tests that the serializer for Provisioning CreateKeysAndCertificate API generates the expected encoding for an
- *"{}" empty
- * payload.
+ * "{}" empty payload.
  */
 TEST( Provisioning_Unit_Serializer, TestSerializeCreateKeysAndCertificatePayloadNominalCase )
 {
@@ -139,6 +223,73 @@ TEST( Provisioning_Unit_Serializer, TestSerializeCreateKeysAndCertificatePayload
 
     /* Release the buffer that was allocated by the serializer function. */
     AwsIotProvisioning_FreePayload( pSerializationBuffer );
+}
+
+/**
+ * @brief Tests that the CSR payload serializer calculates the serialization size, and populates the passed output
+ * parameter when a serialization buffer is not passed to it.
+ */
+TEST( Provisioning_Unit_Serializer, TestCalculateCertFromCsrPayloadSize )
+{
+    size_t bufferSizeNeeded = 0;
+
+    /* Test the serializer function. */
+    TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_SUCCESS,
+                       _AwsIotProvisioning_CalculateCertFromCsrPayloadSize( _testCsrString,
+                                                                            strlen( _testCsrString ),
+                                                                            &bufferSizeNeeded ) );
+    /* Make sure that the output parameter has been populated with the serialization size. */
+    TEST_ASSERT_EQUAL( sizeof( _expectedSerialization ), bufferSizeNeeded );
+}
+
+/**
+ * @brief Tests that the CSR payload serializer populates the buffer with the serialized payload, when
+ * the passed buffer is valid.
+ */
+TEST( Provisioning_Unit_Serializer, TestSerializeCreateCertFromCsrPayloadWithBuffer )
+{
+    size_t reserveOffset;
+
+    /* Allocate buffer that will be used for serialization.
+     * Note: We will allocate more space than the expected serialization size to perform
+     * buffer overrun checks after the serialization operation.  */
+    size_t serializationSize = sizeof( _expectedSerialization );
+    uint8_t * testBuffer = _allocateBufferMemoryWithBufferOverrunReserve(
+        serializationSize,
+        &reserveOffset );
+
+    /* Test the serializer function. */
+    TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_SUCCESS,
+                       _AwsIotProvisioning_SerializeCreateCertFromCsrRequestPayload( _testCsrString,
+                                                                                     strlen( _testCsrString ),
+                                                                                     testBuffer + reserveOffset,
+                                                                                     serializationSize ) );
+    /* Verify the generated serialization in the buffer. */
+    TEST_ASSERT_EQUAL( 0, memcmp( _expectedSerialization,
+                                  testBuffer + 5,
+                                  serializationSize ) );
+
+    /* Make sure that the reserved space in the buffer was not modified. */
+    _checkForBufferOverrun( testBuffer, serializationSize );
+    unity_free_mt( testBuffer );
+}
+
+/**
+ * @brief Tests that the CSR payload serializer returns failure when the passed
+ * serialization buffer has insufficient space for serialization.
+ */
+TEST( Provisioning_Unit_Serializer, TestSerializeCreateCertFromCsrPayloadFailureCase )
+{
+    /* Allocate less than required size for payload buffer. */
+    uint8_t testBuffer[ sizeof( _expectedSerialization ) - 1 ] = { 0 };
+    size_t bufferSize = sizeof( testBuffer );
+
+    /* Test the serializer function. */
+    TEST_ASSERT_EQUAL( AWS_IOT_PROVISIONING_INTERNAL_FAILURE,
+                       _AwsIotProvisioning_SerializeCreateCertFromCsrRequestPayload( _testCsrString,
+                                                                                     strlen( _testCsrString ),
+                                                                                     &testBuffer[ 0 ],
+                                                                                     bufferSize ) );
 }
 
 /**

--- a/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_serializer.c
+++ b/libraries/aws/provisioning/test/unit/aws_iot_tests_provisioning_serializer.c
@@ -137,10 +137,10 @@ void _checkForBufferOverrun( const uint8_t * buffer,
 
     /* Check that both the front and rear reserve spaces in the buffer are not */
     /* overwritten. */
-    for( int index = 0; index < _reserveSize; index++ )
+    for( size_t index = 0; index < _reserveSize; index++ )
     {
-        assert( _bufferOverrunCheckValue == buffer[ index ] );
-        assert( _bufferOverrunCheckValue == buffer[ totalBufferSize - 1 - index ] );
+        TEST_ASSERT_EQUAL( _bufferOverrunCheckValue, buffer[ index ] );
+        TEST_ASSERT_EQUAL( _bufferOverrunCheckValue, buffer[ totalBufferSize - 1 - index ] );
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Implements the response parser for the Certificate-Signing Request API. 
* As the CSR and the (existing) CreateKeysAndCertificate APIs share the same parameters in their response payloads, this PR commonizes the parsing logic for both.
* PR contains unit tests for the new CSR parser

This PR is preceded by PR https://github.com/aggarw13/aws-iot-device-sdk-embedded-C/pull/1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
